### PR TITLE
Make tilt and shift click check state of the controls for out-of-range-errors. Show errors in display panel.

### DIFF
--- a/nion/instrumentation/camera_base.py
+++ b/nion/instrumentation/camera_base.py
@@ -1005,7 +1005,7 @@ class CameraHardwareSource(HardwareSource.HardwareSource):
     def shift_click(self, mouse_position, camera_shape):
         instrument_controller = self.__get_instrument_controller()
         if callable(getattr(instrument_controller, "handle_shift_click", None)):
-            instrument_controller.handle_shift_click(mouse_position=mouse_position, data_shape=camera_shape, camera=self.camera)
+            return instrument_controller.handle_shift_click(mouse_position=mouse_position, data_shape=camera_shape, camera=self.camera)
         else:
             # TODO: remove this backwards compatibility code once everyone updated to new technique above
             if self.__camera_category.lower() == "ronchigram":
@@ -1019,8 +1019,8 @@ class CameraHardwareSource(HardwareSource.HardwareSource):
 
     def tilt_click(self, mouse_position, camera_shape):
         instrument_controller = self.__get_instrument_controller()
-        if callable(getattr(instrument_controller, "handle_shift_click", None)):
-            instrument_controller.handle_tilt_click(mouse_position=mouse_position, data_shape=camera_shape, camera=self.camera)
+        if callable(getattr(instrument_controller, "handle_tilt_click", None)):
+            return instrument_controller.handle_tilt_click(mouse_position=mouse_position, data_shape=camera_shape, camera=self.camera)
         else:
             # TODO: remove this backwards compatibility code once everyone updated to new technique above
             if self.__camera_category.lower() == "ronchigram":

--- a/nionswift_plugin/nion_instrumentation_ui/MultiAcquirePanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/MultiAcquirePanel.py
@@ -637,9 +637,9 @@ class MultiAcquirePanelDelegate:
 
     def __format_time_string(self, acquisition_time):
         if acquisition_time > 3600:
-            time_str = '{0:.1f} hours'.format((int(acquisition_time) + 3599) / 3600)
+            time_str = '{0:.1f} hours'.format(acquisition_time / 3600)
         elif acquisition_time > 90:
-            time_str = '{0:.1f} minutes'.format((int(acquisition_time) + 59) / 60)
+            time_str = '{0:.1f} minutes'.format(acquisition_time / 60)
         else:
             time_str = '{:.1f} seconds'.format(acquisition_time)
         return time_str


### PR DESCRIPTION
Important note: `STEMController.get_control_state()` does now return different values than before. This changes also what the corresponding API function returns, which would change the API. We can go ahead with the API change (probably not the best idea) or make the API function translate from the new return values of `STEMController.get_control_state()` to the old ones.
I did not make this change yet because I wanted to discuss this first.

This adds the required features in the intrumentation base classes for what Niklas requested in his email from 05/13/2020:

> I was tilting around on APM2 using VNC, which means the little temporary message box on AS2 >isn't visible.
>
>There is then no user indication that the tilters are out of range.
>
>The proper way to solve this is:
>
>1- the click to shift /Tilt procedure should query AS2 about the out of range status of the shifts and tilts.
>
>2-If the action would take you further out of range than it already is then it should not do the move and instead flash the frame of the window that is being used for shifting/tilting in red.
>
>This way you get feedback right where you are looking, and you can tilt back easily. 