### PR TITLE
Prepare for masked sum

### DIFF
--- a/nion/instrumentation/camera_base.py
+++ b/nion/instrumentation/camera_base.py
@@ -1031,13 +1031,14 @@ class CameraHardwareSource(HardwareSource.HardwareSource):
         calibration_controls = self.__camera.calibration_controls
         binning = camera_frame_parameters.get("binning", 1)
         data_shape = self.get_expected_dimensions(binning)
-        if processing != "sum_project":
+        if processing in {"sum_project", "sum_masked"}:
+            x_calibration = build_calibration(instrument_controller, calibration_controls, "x", binning, data_shape[0])
+            return (x_calibration,)
+        else:
             y_calibration = build_calibration(instrument_controller, calibration_controls, "y", binning, data_shape[1] if len(data_shape) > 1 else 0)
             x_calibration = build_calibration(instrument_controller, calibration_controls, "x", binning, data_shape[0])
             return (y_calibration, x_calibration)
-        else:
-            x_calibration = build_calibration(instrument_controller, calibration_controls, "x", binning, data_shape[0])
-            return (x_calibration,)
+
 
     def get_camera_intensity_calibration(self, camera_frame_parameters: CameraFrameParameters) -> Calibration.Calibration:
         return build_calibration(self.__instrument_controller, self.__camera.calibration_controls, "intensity")

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -661,7 +661,12 @@ class ScanHardwareSource(HardwareSource.HardwareSource):
 
         camera_readout_size = Geometry.IntSize.make(camera.get_expected_dimensions(camera_frame_parameters.get("binning", 1)))
 
-        camera_readout_size_squeezed = (camera_readout_size.width,) if camera_frame_parameters.get("processing") == "sum_project" else tuple(camera_readout_size)
+        if camera_frame_parameters.get("processing") == "sum_project":
+            camera_readout_size_squeezed = (camera_readout_size.width,)
+        elif camera_frame_parameters.get("processing") == "sum_masked":
+            camera_readout_size_squeezed = (camera_frame_parameters.get("sum_channels", 1),)
+        else:
+            camera_readout_size_squeezed = tuple(camera_readout_size)
 
         scan_size = Geometry.IntSize(h=scan_param_height, w=scan_param_width)
 

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -787,6 +787,7 @@ class ScanHardwareSource(HardwareSource.HardwareSource):
                                 partial_data_info = self.__camera_hardware_source.acquire_synchronized_continue(update_period=update_period)
                                 is_complete = partial_data_info.is_complete
                                 is_canceled = partial_data_info.is_canceled
+                                uncropped_xdata = partial_data_info.uncropped_xdata
                                 # unless it's cancelled or aborted, of course.
                                 if is_canceled or self.__grab_synchronized_aborted:
                                     break

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -787,7 +787,7 @@ class ScanHardwareSource(HardwareSource.HardwareSource):
                                 partial_data_info = self.__camera_hardware_source.acquire_synchronized_continue(update_period=update_period)
                                 is_complete = partial_data_info.is_complete
                                 is_canceled = partial_data_info.is_canceled
-                                uncropped_xdata = partial_data_info.uncropped_xdata
+                                uncropped_xdata = partial_data_info.xdata
                                 # unless it's cancelled or aborted, of course.
                                 if is_canceled or self.__grab_synchronized_aborted:
                                     break

--- a/nionswift_plugin/nion_instrumentation_ui/ScanAcquisition.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanAcquisition.py
@@ -93,13 +93,14 @@ class CameraDataChannel(scan_base.SynchronizedDataChannelInterface):
         scan_calibrations = grab_sync_info.scan_calibrations
         data_calibrations = grab_sync_info.data_calibrations
         data_intensity_calibration = grab_sync_info.data_intensity_calibration
-        data_item = DataItem.DataItem(large_format=True)
+        scan_size = tuple(grab_sync_info.scan_size)
+        camera_readout_size = grab_sync_info.camera_readout_size_squeezed
+        data_shape = scan_size + camera_readout_size
+        large_format = numpy.prod(data_shape) > 2048**2 * 10
+        data_item = DataItem.DataItem(large_format=large_format)
         data_item.title = f"{title_base} ({channel_name})"
         self.__document_model.append_data_item(data_item)
-        if hasattr(data_item, "reserve_data"):
-            scan_size = tuple(grab_sync_info.scan_size)
-            camera_readout_size = grab_sync_info.camera_readout_size_squeezed
-            data_shape = scan_size + camera_readout_size
+        if hasattr(data_item, "reserve_data") and large_format:
             data_descriptor = DataAndMetadata.DataDescriptor(False, 2, len(data_shape) - 2)
             data_item.reserve_data(data_shape=data_shape, data_dtype=numpy.float32, data_descriptor=data_descriptor)
         data_item.dimensional_calibrations = scan_calibrations + data_calibrations


### PR DESCRIPTION
This is what is required (at the bare minimum) to allow cameras returning 0-D data in addition to 1-D (spectra) and 2-D (images).

It introduces a new option for ``CameraFrameParameters.processing``: ``sum_masked``. This tells the sofware that we expect 0D data.

It also introduces another parameter, ``sum_channels``. This is there to allow cameras to create multiple 0D data points. Right now this is not much different from 1D data, but we might want to handle "mutliple 0D channels" different from 1D data in the future.

``sum_channels`` is used in a slightly awkard way right now: It is used by the camera to tell the acquisition system how many 0D data channels it will create. This is the opposite way of how ``frame_parameters`` are intended to be used, which is that the acuqisition system sets them up and passes them to the camera to inform it about how to acquire the data. So maybe we want a better way to accomplish what ´´sum_channels`` is used for right now.