### PR TITLE
Don't ignore metadata coming from camera.

### DIFF
--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -779,7 +779,7 @@ class ScanHardwareSource(HardwareSource.HardwareSource):
                                 valid_rows = partial_data_info.valid_rows
                                 src_top_row = last_valid_rows
                                 metadata = copy.deepcopy(uncropped_xdata.metadata)
-                                metadata["hardware_source"] = copy.deepcopy(scan_info.camera_metadata)
+                                metadata.setdefault("hardware_source", dict()).update(copy.deepcopy(scan_info.camera_metadata))
                                 metadata["scan"] = copy.deepcopy(scan_info.scan_metadata)
                                 metadata["instrument"] = copy.deepcopy(scan_info.instrument_metadata)
                                 metadata["scan"]["valid_rows"] = section_rect[0][0] + valid_rows


### PR DESCRIPTION
Right now any metadata coming from the camera (i.e. in the "hardware_source" group) will be overwritten by the SI code in `scan_base.py`. It gets replaced with the default metadata retrieved before the SI starts. If the camera wants to add metadata that is not known beforehand it cannot place it into the standard group. An example for metadata that only comes up during the acquisition would be saturated pixels.
Out metadata is not standardized very well anyway, but at least we should stick to the (few) standards we already have. Specifically this means that camera metadata should go into the "hardware_source" group, so using a different group is not a good workaround in my opinion.
The "scan" and "instrument" groups can probably stay because there shouldn't be any metadata for this group coming from the camera.