### PR TITLE
Changes to better handle externals, and more generally more than one scan in swift.

### DIFF
--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -733,7 +733,8 @@ def make_scan_display_item_list_model(document_model: DocumentModel.DocumentMode
         if scan_controller:
             for data_channel in scan_controller.data_channels:
                 channel_id = data_channel.channel_id
-                if channel_id and not channel_id.endswith("subscan") and channel_id != "drift":
+                if channel_id and not channel_id.endswith("subscan") and channel_id != "drift"\
+                        and not data_channel.name.endswith("spim"):
                     data_item_channel_reference = document_model.get_data_item_channel_reference(scan_controller.hardware_source_id, channel_id)
                     if data_item_channel_reference and data_item_channel_reference.display_item == display_item:
                         return True
@@ -1210,7 +1211,8 @@ class ScanContextController:
         self.__instrument_added_event_listener = HardwareSource.HardwareSourceManager().instrument_added_event.listen(self.register_instrument)
         self.__instrument_removed_event_listener = HardwareSource.HardwareSourceManager().instrument_removed_event.listen(self.unregister_instrument)
         for instrument in HardwareSource.HardwareSourceManager().instruments:
-            self.register_instrument(instrument)
+            if instrument.instrument_id != "external_scan_controller":
+                self.register_instrument(instrument)
 
     def close(self) -> None:
         # any instrument that was registered needs to be unregistered.
@@ -1257,7 +1259,7 @@ _pending_document_models: typing.List[DocumentModel.DocumentModel] = list()
 
 
 def component_registered(component: Registry._ComponentType, component_types: typing.Set[str]) -> None:
-    if "stem_controller" in component_types:
+    if "stem_controller" in component_types and component.instrument_id != "external_scan_controller":
         HardwareSource.HardwareSourceManager().register_instrument(component.instrument_id, component)
     if "document_model" in component_types:
         document_model = typing.cast(DocumentModel.DocumentModel, component)
@@ -1268,7 +1270,7 @@ def component_registered(component: Registry._ComponentType, component_types: ty
 
 
 def component_unregistered(component: Registry._ComponentType, component_types: typing.Set[str]) -> None:
-    if "stem_controller" in component_types:
+    if "stem_controller" in component_types and component.instrument_id != "external_scan_controller":
         HardwareSource.HardwareSourceManager().unregister_instrument(component.instrument_id)
     if "document_model" in component_types:
         document_model = typing.cast(DocumentModel.DocumentModel, component)

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -1836,7 +1836,7 @@ scan_control_panels = dict()
 
 def register_scan_panel(hardware_source: HardwareSource.HardwareSource) -> None:
     # NOTE: if scan control panel is not appearing, stop here and make sure aliases.ini is present in the workspace
-    if hardware_source.features.get("is_scanning", False):
+    if hardware_source.features.get("is_scanning", False) and hardware_source.hardware_source_id != "orsay_scan_device":
         panel_id = "scan-control-panel-" + hardware_source.hardware_source_id
         scan_control_panels[hardware_source.hardware_source_id] = panel_id
 
@@ -1887,7 +1887,7 @@ def register_scan_panel(hardware_source: HardwareSource.HardwareSource) -> None:
         Workspace.WorkspaceManager().register_panel(ScanControlPanel, panel_id, name, ["left", "right"], "left", properties)
 
 def unregister_scan_panel(hardware_source: HardwareSource.HardwareSource) -> None:
-    if hardware_source.features.get("is_scanning", False):
+    if hardware_source.features.get("is_scanning", False) and hardware_source.hardware_source_id != "orsay_scan_device":
         factory_id = "scan-live-" + hardware_source.hardware_source_id
         DisplayPanel.DisplayPanelManager().unregister_display_panel_controller_factory(factory_id)
         panel_id = scan_control_panels.pop(hardware_source.hardware_source_id)


### PR DESCRIPTION
move profiles and channels initialisation from __init()__ to a separate function so that it can be easily overriden
Temporary ?
do not register/unregister component if it is an orsay_scan_device

stem_controller:
do not add channel_id ending with spim to make_scan_display_item_list
Temporary ?
does not register_instrument if it is an external_scan_controller
do not register/unregister component if it is an external_scan_controller

ScanCntrolPanel:
Temporary ?
do not register/unregister component if it is an orsay_scan_device