### PR TITLE
Improve DriftTracker. Separate our cross-correlation. Allow multiple drift sources.

### DIFF
--- a/nion/instrumentation/test/SynchronizedAcquisition_test.py
+++ b/nion/instrumentation/test/SynchronizedAcquisition_test.py
@@ -628,13 +628,18 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
             self.assertTrue(0.9 < dist_nm < 1.1)
             self.assertTrue(0.9 < abs(last_delta_nm.width) < 1.1)
             self.assertTrue(abs(last_delta_nm.height) < 0.1)
-            stem_controller.SetValDeltaAndConfirm("CSH.x", 2e-9, 1.0, 1000)
+            stem_controller.SetValDeltaAndConfirm("CSH.x", 2e-9, 2.0, 1000)
             drift_correction_behavior.prepare_section(utc_time=drift_tracker._last_entry_utc_time)
             last_delta_nm = drift_tracker.last_delta_nm
             dist_nm = math.sqrt(pow(last_delta_nm.width, 2) + pow(last_delta_nm.height, 2))
             self.assertTrue(1.9 < dist_nm < 2.1)
             self.assertTrue(1.9 < abs(last_delta_nm.width) < 2.1)
             self.assertTrue(abs(last_delta_nm.height) < 0.1)
+            total_delta_nm = drift_tracker.total_delta_nm
+            self.assertTrue(2.8 < abs(total_delta_nm.width) < 3.2)
+            self.assertTrue(abs(last_delta_nm.height) < 0.1)
+            expected_drift_data_frame = [[0.0, 0.0], [1.0, 3.0], [1.0, 3.0]]
+            self.assertTrue(numpy.allclose(drift_tracker.drift_data_frame[:-1], expected_drift_data_frame, atol=0.2))
 
     def test_drift_corrector_with_drift_sub_area_rotation(self):
         # for this test, drift should be in a constant direction


### PR DESCRIPTION
I'm creating this as a draft for now so that you can already review the basic concept. I'm going to add a dedicated test file ``DriftTracker_test.py`` and test the different scenarios that the revamped DriftTracker supports now.

The idea behind the changes is that we can track multiple sources of drift data and collect the measured drift rates in one place, the ``DriftTracker`` class.
I've also separated out the cross-correlation algorithm from the ``DriftTracker`` class, so that we can use different algorithms for different usecases. One question I'm not sure about yet is if we want to allow different cross-correlation algorithms for different ``DriftDataSources``. Right now you can only define one algorithm which will be used for all calculations. There is the option to change the algorithm before each call to ``submit_image``, so you can still use different ones for different sources. But we might want to store the preferred cross-correlation algorithm with each ``DriftDataSource`` instead.