### PR TITLE
secondary scan device

### DIFF
--- a/nion/instrumentation/DriftTracker.py
+++ b/nion/instrumentation/DriftTracker.py
@@ -267,7 +267,7 @@ class DriftCorrectionBehavior:
         self.__scan_frame_parameters.subscan_fractional_size = None
         self.__scan_frame_parameters.subscan_fractional_center = None
         self.__scan_frame_parameters.subscan_rotation = 0.0
-        self.__scan_frame_parameters.channel_override = "drift"
+        self.__scan_frame_parameters.channel_variant = "drift"
         self.__drift_tracker.reset()
 
     def prepare_section(self, *, utc_time: typing.Optional[datetime.datetime] = None) -> None:

--- a/nion/instrumentation/HardwareSource.py
+++ b/nion/instrumentation/HardwareSource.py
@@ -869,14 +869,6 @@ class HardwareSource(typing.Protocol):
     def is_recording(self) -> bool:
         return False
 
-    @property
-    def data_channel_count(self) -> int:
-        return len(self.data_channels)
-
-    @property
-    def data_channels(self) -> typing.Sequence[DataChannel]:
-        return list()
-
     # private. do not use outside instrumentation-kit.
 
     data_channel_states_updated: Event.Event
@@ -895,6 +887,7 @@ class HardwareSource(typing.Protocol):
     def get_channel_count(self) -> int: ...
     def get_channel_enabled(self, channel_index: int) -> bool: ...
     def get_channel_id(self, channel_index: int) -> typing.Optional[str]: ...
+    def get_channel_name(self, channel_index: int) -> typing.Optional[str]: ...
     def set_channel_enabled(self, channel_index: int, enabled: bool) -> None: ...
     def data_channel_map_updated(self, data_channel_map: typing.Mapping[str, DataItem.DataItem]) -> None: ...
     def set_record_frame_parameters(self, frame_parameters: FrameParameters) -> None: ...
@@ -1373,7 +1366,7 @@ class ConcreteHardwareSource(Observable.Observable, HardwareSource):
         src_channel_index = data_channel.src_channel_index
         sum_processor = data_channel.processor
         if sum_processor and src_channel_index is not None:
-            return self.data_channels[src_channel_index]
+            return self.__data_channel_list_model.items[src_channel_index]
         return None
 
     def get_property(self, name: str) -> typing.Any:
@@ -1414,6 +1407,9 @@ class ConcreteHardwareSource(Observable.Observable, HardwareSource):
         return channel_index == 0
 
     def get_channel_id(self, channel_index: int) -> typing.Optional[str]:
+        return None
+
+    def get_channel_name(self, channel_index: int) -> typing.Optional[str]:
         return None
 
     def set_channel_enabled(self, channel_index: int, enabled: bool) -> None:

--- a/nion/instrumentation/HardwareSource.py
+++ b/nion/instrumentation/HardwareSource.py
@@ -1325,14 +1325,6 @@ class ConcreteHardwareSource(Observable.Observable, HardwareSource):
                 return new_xdatas
 
     @property
-    def data_channel_count(self) -> int:
-        return len(self.__data_channel_list_model.items)
-
-    @property
-    def data_channels(self) -> typing.Sequence[DataChannel]:
-        return self.__data_channel_list_model.items
-
-    @property
     def data_channel_list_model(self) -> ListModel.ListModel[DataChannel]:
         return self.__data_channel_list_model
 

--- a/nion/instrumentation/ListListener.py
+++ b/nion/instrumentation/ListListener.py
@@ -1,0 +1,115 @@
+# a set of classes to make observing lists easier. these will eventually be moved to nionutils.
+
+from __future__ import annotations
+
+# system imports
+import typing
+import weakref
+
+# local imports
+from nion.utils import Event
+from nion.utils import ListModel
+from nion.utils.ReferenceCounting import weak_partial
+
+
+class ListItemHandlerLike(typing.Protocol):
+    def begin(self, item_stack: typing.Sequence[typing.Any]) -> None: ...
+    def end(self) -> None: ...
+
+
+class ListItemHandlerFactoryLike(typing.Protocol):
+    def make(self) -> ListItemHandlerLike: ...
+
+
+class ListItemEventsHandler(ListItemHandlerLike):
+    def __init__(self, event_map: typing.Mapping[str, Event.EventListenerCallableType]) -> None:
+        self.__listeners: typing.Dict[str, Event.EventListener] = dict()
+        self.__event_map = event_map
+
+    def begin(self, item_stack: typing.Sequence[typing.Any]) -> None:
+        for event_name in self.__event_map.keys():
+            item = item_stack[-1]
+            self.__listeners[event_name] = getattr(item, event_name).listen(
+                weak_partial(ListItemEventsHandler.__bounce, self, event_name, [weakref.ref(i) for i in item_stack]))
+
+    def end(self) -> None:
+        pass
+
+    def __bounce(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        event_name = args[0]
+        item_stack = [a() for a in args[1]]
+        if all(item_stack):
+            self.__event_map[event_name](*item_stack, *args[2:], **kwargs)
+
+
+class ListItemEventsHandlerFactory(ListItemHandlerFactoryLike):
+    def __init__(self, event_map: typing.Mapping[str, Event.EventListenerCallableType]) -> None:
+        self.__event_map = event_map
+
+    def make(self) -> ListItemHandlerLike:
+        return ListItemEventsHandler(self.__event_map)
+
+
+class ListItemItemsHandlerBase(ListItemHandlerLike):
+    def __init__(self, factory: ListItemHandlerFactoryLike, *, key: typing.Optional[str] = None) -> None:
+        self.__factory = factory
+        self.__key = key or "items"
+        self.__item_handlers: typing.List[ListItemHandlerLike] = list()
+
+    def begin(self, item_stack: typing.Sequence[typing.Any]) -> None:
+        raise NotImplementedError()
+
+    def end(self) -> None:
+        pass
+
+    def _begin(self, list_model: ListModel.ListModel[typing.Any], item_stack: typing.Sequence[typing.Any]) -> None:
+        def item_inserted(key: str, item: typing.Any, before_index: int) -> None:
+            if key == self.__key:
+                a = self.__factory.make()
+                self.__item_handlers.insert(before_index, a)
+                a.begin(list(item_stack) + [item])
+
+        def item_removed(key: str, item: typing.Any, index: int) -> None:
+            if key == self.__key:
+                self.__item_handlers[index].end()
+                del self.__item_handlers[index]
+
+        self.__item_inserted_listener = list_model.item_inserted_event.listen(item_inserted)
+        self.__item_removed_listener = list_model.item_removed_event.listen(item_removed)
+
+        for i in range(len(list_model.items)):
+            item_inserted(self.__key, list_model.items[i], i)
+
+
+class ListItemItemsHandler(ListItemItemsHandlerBase):
+    def __init__(self, list_key: str, factory: ListItemHandlerFactoryLike, *, key: typing.Optional[str] = None) -> None:
+        super().__init__(factory, key=key)
+        self.__list_key = list_key
+
+    def begin(self, item_stack: typing.Sequence[typing.Any]) -> None:
+        item = item_stack[-1]
+        self._begin(getattr(item, self.__list_key), item_stack)
+
+    def end(self) -> None:
+        pass
+
+
+class ListItemItemsHandlerFactory(ListItemHandlerFactoryLike):
+    def __init__(self, list_key: str, factory: ListItemHandlerFactoryLike, *, key: typing.Optional[str] = None) -> None:
+        self.__list_key = list_key
+        self.__factory = factory
+        self.__key = key
+
+    def make(self) -> ListItemHandlerLike:
+        return ListItemItemsHandler(self.__list_key, self.__factory, key=self.__key)
+
+
+class ListListener(ListItemItemsHandlerBase):
+    """Listen to events on a list model and send them to listeners.
+
+    The list listener watches for items inserted/removed from the model and adds listeners based on the mapping
+    of event names to functions; the function will be called with the inserted/removed item as the first parameter.
+    """
+    def __init__(self, list_model: ListModel.ListModel[typing.Any], factory: ListItemHandlerFactoryLike, *, key: typing.Optional[str] = None) -> None:
+        super().__init__(factory, key=key)
+        self._begin(list_model, list())

--- a/nion/instrumentation/camera_base.py
+++ b/nion/instrumentation/camera_base.py
@@ -1308,7 +1308,7 @@ class CameraHardwareSource2(HardwareSource.ConcreteHardwareSource, CameraHardwar
         if self.__camera_category.lower() == "eels":
             self.features["is_eels_camera"] = True
         if getattr(camera, "has_processed_channel", True if self.__camera_category.lower() == "eels" else False):
-            self.processor = HardwareSource.SumProcessor(Geometry.FloatRect(Geometry.FloatPoint(0.25, 0.0), Geometry.FloatSize(0.5, 1.0)))
+            self.processor = HardwareSource.SumProcessor()
         self.features["has_processed_channel"] = self.processor is not None
         if hasattr(camera_settings, "masks"):
             self.features["has_masked_sum_option"] = True
@@ -1916,7 +1916,7 @@ class CameraHardwareSource3(HardwareSource.ConcreteHardwareSource, CameraHardwar
         if self.__camera_category.lower() == "eels":
             self.features["is_eels_camera"] = True
         if getattr(camera, "has_processed_channel", True if self.__camera_category.lower() == "eels" else False):
-            self.processor = HardwareSource.SumProcessor(Geometry.FloatRect(Geometry.FloatPoint(0.25, 0.0), Geometry.FloatSize(0.5, 1.0)))
+            self.processor = HardwareSource.SumProcessor()
         self.features["has_processed_channel"] = self.processor is not None
         if hasattr(camera_settings, "masks"):
             self.features["has_masked_sum_option"] = True

--- a/nion/instrumentation/camera_base.py
+++ b/nion/instrumentation/camera_base.py
@@ -1428,12 +1428,6 @@ class CameraHardwareSource2(HardwareSource.ConcreteHardwareSource, CameraHardwar
     def grab_buffer(self, count: int, *, start: typing.Optional[int] = None, **kwargs: typing.Any) -> typing.Optional[typing.List[typing.List[DataAndMetadata.DataAndMetadata]]]:
         return None
 
-    def make_reference_key(self, **kwargs: typing.Any) -> str:
-        reference_key = kwargs.get("reference_key")
-        if reference_key:
-            return "_".join([self.hardware_source_id, str(reference_key)])
-        return self.hardware_source_id
-
     @property
     def camera_settings(self) -> CameraSettings:
         return self.__camera_settings
@@ -2063,12 +2057,6 @@ class CameraHardwareSource3(HardwareSource.ConcreteHardwareSource, CameraHardwar
 
     def grab_buffer(self, count: int, *, start: typing.Optional[int] = None, **kwargs: typing.Any) -> typing.Optional[typing.List[typing.List[DataAndMetadata.DataAndMetadata]]]:
         return None
-
-    def make_reference_key(self, **kwargs: typing.Any) -> str:
-        reference_key = kwargs.get("reference_key")
-        if reference_key:
-            return "_".join([self.hardware_source_id, str(reference_key)])
-        return self.hardware_source_id
 
     @property
     def camera_settings(self) -> CameraSettings:

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -658,7 +658,6 @@ class ScanHardwareSource(HardwareSource.HardwareSource, typing.Protocol):
     @property
     def selected_profile_index(self) -> int: raise NotImplementedError()
 
-    def set_channel_enabled(self, channel_index: int, enabled: bool) -> None: ...
     def get_frame_parameters(self, profile_index: int) -> ScanFrameParameters: ...
     def set_frame_parameters(self, profile_index: int, frame_parameters: ScanFrameParameters) -> None: ...
 
@@ -753,7 +752,6 @@ class ScanHardwareSource(HardwareSource.HardwareSource, typing.Protocol):
     def periodic(self) -> None: ...
     def get_enabled_channels(self) -> typing.Sequence[int]: ...
     def get_channel_state(self, channel_index: int) -> ChannelState: ...
-    def get_channel_enabled(self, channel_index: int) -> bool: ...
     def get_channel_index(self, channel_id: str) -> typing.Optional[int]: ...
     def get_subscan_channel_info(self, channel_index: int, channel_id: str, channel_name: str) -> typing.Tuple[int, str, str]: ...
     def apply_scan_context_subscan(self, frame_parameters: ScanFrameParameters, size: typing.Optional[typing.Tuple[int, int]] = None) -> None: ...
@@ -774,12 +772,7 @@ class ScanHardwareSource(HardwareSource.HardwareSource, typing.Protocol):
     def get_buffer_data(self, start: int, count: int) -> typing.List[typing.List[typing.Dict[str, typing.Any]]]: ...
     def scan_immediate(self, frame_parameters: ScanFrameParameters) -> None: ...
     def calculate_flyback_pixels(self, frame_parameters: ScanFrameParameters) -> int: ...
-
-    def get_enabled_context_data_channels(self) -> typing.Sequence[HardwareSource.DataChannel]:
-        # return the enabled data channels functioning as scan contexts.
-        enabled_channel_indexes = self.get_enabled_channels()
-        enabled_data_channels = [self.data_channels[channel_index] for channel_index in enabled_channel_indexes]
-        return tuple(filter(lambda data_channel: data_channel.is_context, enabled_data_channels))
+    def get_enabled_data_channels(self) -> typing.Sequence[HardwareSource.DataChannel]: ...
 
     record_index: int
     priority: int = 100
@@ -1708,7 +1701,7 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
 
     @property
     def channel_count(self) -> int:
-        return len(self.__device.channels_enabled)
+        return self.get_channel_count()
 
     def get_channel_state(self, channel_index: int) -> ChannelState:
         channels_enabled = self.__device.channels_enabled
@@ -1716,9 +1709,16 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
         name = self.__device.get_channel_name(channel_index)
         return self.__make_channel_state(channel_index, name, channels_enabled[channel_index])
 
+    def get_channel_count(self) -> int:
+        return len(self.__device.channels_enabled)
+
     def get_channel_enabled(self, channel_index: int) -> bool:
         assert 0 <= channel_index < self.__device.channel_count
         return self.__device.channels_enabled[channel_index]
+
+    def get_channel_id(self, channel_index: int) -> typing.Optional[str]:
+        assert 0 <= channel_index < self.__device.channel_count
+        return self.__make_channel_id(channel_index)
 
     def set_channel_enabled(self, channel_index: int, enabled: bool) -> None:
         changed = self.__device.set_channel_enabled(channel_index, enabled)
@@ -1917,6 +1917,10 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
             return self.__device.calculate_flyback_pixels(frame_parameters)
         return getattr(self.__device, "flyback_pixels", 0)
 
+    def get_enabled_data_channels(self) -> typing.Sequence[HardwareSource.DataChannel]:
+        enabled_channel_indexes = self.get_enabled_channels()
+        return [self.data_channels[channel_index] for channel_index in enabled_channel_indexes]
+
     def __probe_state_changed(self, probe_state: str, probe_position: typing.Optional[Geometry.FloatPoint]) -> None:
         # subclasses will override _set_probe_position
         # probe_state can be 'parked', or 'scanning'
@@ -2087,17 +2091,13 @@ class ScanFrameDataStream(Acquisition.DataStream):
                         buffer_data[available_rows:valid_rows] = data_and_metadata[available_rows:valid_rows]
                         self.__available_rows[channel] = valid_rows
 
-        self.__data_channel_listeners = list()
-        for data_channel in scan_hardware_source.data_channels:
-            self.__data_channel_listeners.append(data_channel.data_channel_updated_event.listen(functools.partial(update_data, data_channel)))
+        self.__data_channel_listener = self.__scan_hardware_source.data_channel_updated_event.listen(update_data)
 
     def about_to_delete(self) -> None:
         if self.__record_task:
             self.__record_task.close()
             self.__record_task = typing.cast(typing.Any, None)
-        for data_channel_listener in self.__data_channel_listeners:
-            data_channel_listener.close()
-        self.__data_channel_listeners.clear()
+        self.__data_channel_listener = typing.cast(typing.Any, None)
         super().about_to_delete()
 
     @property

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -348,7 +348,17 @@ def update_scan_properties(properties: typing.MutableMapping[str, typing.Any], s
 
 
 # set the calibrations for this image. does not touch metadata.
-def update_scan_data_element(data_element: typing.MutableMapping[str, typing.Any], scan_frame_parameters: ScanFrameParameters, data_shape: typing.Tuple[int, int], channel_name: str, channel_id: str, channel_variant: typing.Optional[str], scan_properties: typing.Mapping[str, typing.Any]) -> None:
+def update_data_channel_specifier(data_element: typing.MutableMapping[str, typing.Any], data_channel_specifier: HardwareSource.DataChannelSpecifier) -> None:
+    data_element["title"] = data_channel_specifier.channel_name
+    data_element["version"] = 1
+    data_element["channel_id"] = data_channel_specifier.channel_id  # needed to match to the channel
+    if data_channel_specifier.channel_variant:
+        data_element["channel_variant"] = data_channel_specifier.channel_variant  # needed to match to the channel
+    data_element["channel_name"] = data_channel_specifier.channel_name  # needed to match to the channel
+
+
+# set the calibrations for this image. does not touch metadata.
+def update_scan_data_element_spatial_calibrations(data_element: typing.MutableMapping[str, typing.Any], scan_frame_parameters: ScanFrameParameters, data_shape: typing.Tuple[int, int], scan_properties: typing.Mapping[str, typing.Any]) -> None:
     pixel_time_us = float(scan_properties["pixel_time_us"])
     line_time_us = float(scan_properties["line_time_us"]) if "line_time_us" in scan_properties else pixel_time_us * data_shape[1]
     center_x_nm = scan_frame_parameters.center_nm.x
@@ -362,34 +372,27 @@ def update_scan_data_element(data_element: typing.MutableMapping[str, typing.Any
         fractional_size = scan_frame_parameters.subscan_fractional_size[1] if scan_frame_parameters.subscan_fractional_size else 1.0
         pixel_size = scan_frame_parameters.subscan_pixel_size[1] if scan_frame_parameters.subscan_pixel_size else scan_frame_parameters.pixel_size[1]
         pixel_size_nm = fov_nm * fractional_size / pixel_size
-    data_element["title"] = channel_name
-    data_element["version"] = 1
-    data_element["channel_id"] = channel_id  # needed to match to the channel
-    if channel_variant:
-        data_element["channel_variant"] = channel_variant  # needed to match to the channel
-    data_element["channel_name"] = channel_name  # needed to match to the channel
-    if not "spatial_calibrations" in data_element:
-        assert len(data_shape) in (1, 2)
-        if scan_properties.get("calibration_style") == "time":
-            if len(data_shape) == 2:
-                data_element["spatial_calibrations"] = (
-                    {"offset": 0.0, "scale": line_time_us / 1E6, "units": "s"},
-                    {"offset": 0.0, "scale": pixel_time_us / 1E6, "units": "s"}
-                )
-            elif len(data_shape) == 1:
-                data_element["spatial_calibrations"] = (
-                    {"offset": 0.0, "scale": pixel_time_us / 1E6, "units": "s"}
-                )
-        else:
-            if len(data_shape) == 2:
-                data_element["spatial_calibrations"] = (
-                    {"offset": -center_y_nm - pixel_size_nm * data_shape[0] * 0.5, "scale": pixel_size_nm, "units": "nm"},
-                    {"offset": -center_x_nm - pixel_size_nm * data_shape[1] * 0.5, "scale": pixel_size_nm, "units": "nm"}
-                )
-            elif len(data_shape) == 1:
-                data_element["spatial_calibrations"] = (
-                    {"offset": -center_x_nm - pixel_size_nm * data_shape[1] * 0.5, "scale": pixel_size_nm, "units": "nm"}
-                )
+    assert len(data_shape) in (1, 2)
+    if scan_properties.get("calibration_style") == "time":
+        if len(data_shape) == 2:
+            data_element["spatial_calibrations"] = (
+                {"offset": 0.0, "scale": line_time_us / 1E6, "units": "s"},
+                {"offset": 0.0, "scale": pixel_time_us / 1E6, "units": "s"}
+            )
+        elif len(data_shape) == 1:
+            data_element["spatial_calibrations"] = (
+                {"offset": 0.0, "scale": pixel_time_us / 1E6, "units": "s"}
+            )
+    else:
+        if len(data_shape) == 2:
+            data_element["spatial_calibrations"] = (
+                {"offset": -center_y_nm - pixel_size_nm * data_shape[0] * 0.5, "scale": pixel_size_nm, "units": "nm"},
+                {"offset": -center_x_nm - pixel_size_nm * data_shape[1] * 0.5, "scale": pixel_size_nm, "units": "nm"}
+            )
+        elif len(data_shape) == 1:
+            data_element["spatial_calibrations"] = (
+                {"offset": -center_x_nm - pixel_size_nm * data_shape[1] * 0.5, "scale": pixel_size_nm, "units": "nm"}
+            )
 
 
 def update_scan_metadata(scan_metadata: typing.MutableMapping[str, typing.Any], hardware_source_id: str, display_name: str, scan_frame_parameters: ScanFrameParameters, scan_id: typing.Optional[uuid.UUID], scan_properties: typing.Mapping[str, typing.Any]) -> None:
@@ -550,6 +553,10 @@ class ScanAcquisitionTask(HardwareSource.AcquisitionTask):
             scan_id = self.__scan_id
             channel_name = self.__device.get_channel_name(channel_index)
             is_subscan = self.__frame_parameters.subscan_pixel_size and not self.__frame_parameters.subscan_type_partial
+            # channel variant can be passed back from the acquisition device; but if it isn't, then subscan is
+            # added if the subscan_pixel_size is set. the scan devices (modules) will still have a chance to modify
+            # the channel specifier via the DataChannelDelegateProtocol.map_data_channel_specifier before the channel
+            # specifier is used to send the data to a data channel.
             channel_variant = self.__frame_parameters.channel_variant
             channel_variant = channel_variant or ("subscan" if is_subscan else None)
             # create the 'data_element' in the format that must be returned from this method
@@ -559,7 +566,13 @@ class ScanAcquisitionTask(HardwareSource.AcquisitionTask):
             update_instrument_properties(instrument_metadata, self.__stem_controller, self.__device)
             if instrument_metadata:
                 data_element["metadata"].setdefault("instrument", dict()).update(instrument_metadata)
-            update_scan_data_element(data_element, self.__frame_parameters, _data.shape, channel_name, channel_id, channel_variant, _scan_properties)
+            update_data_channel_specifier(data_element, HardwareSource.DataChannelSpecifier(channel_id, channel_variant, channel_name))
+            # the spatial calibrations from the incoming data override the calculated calibrations.
+            # also, the calculated calibrations are only valid for 2D incoming data.
+            if "spatial_calibrations" in _data_element:
+                data_element["spatial_calibrations"] = copy.deepcopy(_data_element["spatial_calibrations"])
+            else:
+                update_scan_data_element_spatial_calibrations(data_element, self.__frame_parameters, _data.shape, _scan_properties)
             update_scan_metadata(data_element["metadata"].setdefault("scan", dict()), self.hardware_source_id, self.__display_name, self.__frame_parameters, scan_id, _scan_properties)
             update_detector_metadata(data_element["metadata"].setdefault("hardware_source", dict()), self.hardware_source_id, self.__display_name, _data.shape, self.__frame_number, channel_name, channel_id, _scan_properties)
             update_data_element(data_element, complete, sub_area, _data)
@@ -1871,7 +1884,13 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
                     update_instrument_properties(instrument_metadata, self.__stem_controller, self.__device)
                     if instrument_metadata:
                         data_element["metadata"].setdefault("instrument", dict()).update(instrument_metadata)
-                    update_scan_data_element(data_element, self.__frame_parameters, _data.shape, channel_name, channel_id, channel_variant, _scan_properties)
+                    update_data_channel_specifier(data_element, HardwareSource.DataChannelSpecifier(channel_id, channel_variant, channel_name))
+                    # the spatial calibrations from the incoming data override the calculated calibrations.
+                    # also, the calculated calibrations are only valid for 2D incoming data.
+                    if "spatial_calibrations" in _data_element:
+                        data_element["spatial_calibrations"] = copy.deepcopy(_data_element["spatial_calibrations"])
+                    else:
+                        update_scan_data_element_spatial_calibrations(data_element, self.__frame_parameters, _data.shape, _scan_properties)
                     update_scan_metadata(data_element["metadata"].setdefault("scan", dict()), self.hardware_source_id, self.display_name, self.__frame_parameters, scan_id, _scan_properties)
                     update_detector_metadata(data_element["metadata"].setdefault("hardware_source", dict()), self.hardware_source_id, self.display_name, _data.shape, None, channel_name, channel_id, _scan_properties)
                     data_element["data"] = _data

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -1565,7 +1565,7 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
     def drift_enabled(self, enabled: bool) -> None:
         if enabled:
             if not self.drift_channel_id:
-                self.drift_channel_id = self.data_channels[0].channel_id
+                self.drift_channel_id = self.get_channel_id(0)
             if not self.drift_region:
                 self.drift_region = Geometry.FloatRect.from_center_and_size(Geometry.FloatPoint(y=0.25, x=0.75), Geometry.FloatSize(h=0.25, w=0.25))
         else:
@@ -1719,6 +1719,10 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
     def get_channel_id(self, channel_index: int) -> typing.Optional[str]:
         assert 0 <= channel_index < self.__device.channel_count
         return self.__make_channel_id(channel_index)
+
+    def get_channel_name(self, channel_index: int) -> typing.Optional[str]:
+        assert 0 <= channel_index < self.__device.channel_count
+        return self.__device.get_channel_name(channel_index)
 
     def set_channel_enabled(self, channel_index: int, enabled: bool) -> None:
         changed = self.__device.set_channel_enabled(channel_index, enabled)

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -766,7 +766,6 @@ class ScanHardwareSource(HardwareSource.HardwareSource, typing.Protocol):
     def increase_pmt(self, channel_index: int) -> None: ...
     def decrease_pmt(self, channel_index: int) -> None: ...
     def get_channel_index_for_data_channel_index(self, data_channel_index: int) -> int: ...
-    def get_data_channel_state(self, channel_index: int) -> typing.Tuple[typing.Optional[str], typing.Optional[str], bool]: ...
     def grab_synchronized_get_info(self, *, scan_frame_parameters: ScanFrameParameters, camera: camera_base.CameraHardwareSource, camera_frame_parameters: camera_base.CameraFrameParameters) -> GrabSynchronizedInfo: ...
     def get_current_frame_time(self) -> float: ...
     def get_buffer_data(self, start: int, count: int) -> typing.List[typing.List[typing.Dict[str, typing.Any]]]: ...
@@ -1732,18 +1731,6 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
     def get_subscan_channel_info(self, channel_index: int, channel_id: str, channel_name: str) -> typing.Tuple[int, str, str]:
         return channel_index + self.channel_count, channel_id + "_subscan", " ".join((channel_name, _("SubScan")))
 
-    def get_data_channel_state(self, channel_index: int) -> typing.Tuple[typing.Optional[str], typing.Optional[str], bool]:
-        # channel indexes larger than then the channel count will be subscan channels
-        if channel_index < self.channel_count:
-            channel_state = self.get_channel_state(channel_index)
-            return channel_state.channel_id, channel_state.name, channel_state.enabled if not self.subscan_enabled else False
-        elif channel_index < self.channel_count * 2:
-            channel_state = self.get_channel_state(channel_index - self.channel_count)
-            subscan_channel_index, subscan_channel_id, subscan_channel_name = self.get_subscan_channel_info(channel_index, channel_state.channel_id, channel_state.name)
-            return subscan_channel_id, subscan_channel_name, channel_state.enabled if self.subscan_enabled else False
-        else:
-            return self.data_channels[channel_index].channel_id, self.data_channels[channel_index].name, False
-
     def get_channel_index_for_data_channel_index(self, data_channel_index: int) -> int:
         return data_channel_index % self.channel_count
 
@@ -1804,7 +1791,7 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
             if list(channel_states) != list(self.__channel_states):
                 self.__pending_channel_states = list(channel_states)
                 self.__task_queue.put(channel_states_changed)
-        self.data_channel_states_updated.fire(self.data_channels)
+        self.data_channels_updated()
 
     def get_channel_index(self, channel_id: str) -> typing.Optional[int]:
         for channel_index in range(self.channel_count):
@@ -1975,8 +1962,8 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
         self.__stem_controller.validate_probe_position()
 
     # override from the HardwareSource parent class.
-    def data_channel_map_updated(self, data_channel_map: typing.Mapping[str, DataItem.DataItem]) -> None:
-        self.__stem_controller._update_scan_channel_map(data_channel_map)
+    def data_channels_updated(self) -> None:
+        self.__stem_controller.data_channels_updated()
 
     @property
     def use_hardware_simulator(self) -> bool:

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -615,6 +615,7 @@ def apply_section_rect(scan_frame_parameters: ScanFrameParameters, acquisition_t
 class ScanDevice(typing.Protocol):
     scan_device_id: str
     scan_device_name: str
+    scan_device_is_secondary: bool = False
 
     def close(self) -> None: ...
     def get_channel_name(self, channel_index: int) -> str: ...

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -2072,12 +2072,12 @@ class ScanFrameDataStream(Acquisition.DataStream):
 
         self.__started = False
 
-        def update_data(data_channel: HardwareSource.DataChannel, data_and_metadata: DataAndMetadata.DataAndMetadata) -> None:
+        def update_data(data_channel_event_args: HardwareSource.DataChannelEventArgs, data_and_metadata: DataAndMetadata.DataAndMetadata) -> None:
             # when data arrives here, it will be part of the overall data item, even if it is only a partial
             # acquire of the data item. so the buffer data shape will reflect the overall data item.
             if self.__started:
                 with self.__lock:
-                    channel_id = data_channel.channel_id
+                    channel_id = data_channel_event_args.channel_id
                     assert channel_id
                     channel_index = scan_hardware_source.get_channel_index(channel_id)
                     channel = Acquisition.Channel(scan_hardware_source.hardware_source_id, str(channel_index))

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -205,7 +205,6 @@ class STEMController(Observable.Observable):
         self.__drift_region: typing.Optional[Geometry.FloatRect] = None
         self.__drift_rotation = 0.0
         self.__drift_settings = DriftCorrectionSettings()
-        self.__scan_context_channel_map : typing.Dict[str, DataItem.DataItem] = dict()
         self.scan_context_data_items_changed_event = Event.Event()
         self.scan_context_changed_event = Event.Event()
         self.__ronchigram_camera: typing.Optional[camera_base.CameraHardwareSource] = None
@@ -214,7 +213,7 @@ class STEMController(Observable.Observable):
         self.__drift_tracker: typing.Optional[DriftTracker.DriftTracker] = None
 
     def close(self) -> None:
-        self.__scan_context_channel_map = typing.cast(typing.Any, None)
+        pass
 
     def reset(self) -> None:
         self.__probe_position = None
@@ -231,7 +230,6 @@ class STEMController(Observable.Observable):
         self.__drift_region = None
         self.__drift_rotation = 0.0
         self.__drift_settings = DriftCorrectionSettings()
-        self.__scan_context_channel_map.clear()
 
     # configuration methods
 
@@ -389,15 +387,11 @@ class STEMController(Observable.Observable):
             self.notify_property_changed("drift_settings")
 
     def disconnect_probe_connections(self) -> None:
-        self.__scan_context_channel_map = dict()
         self.scan_context_data_items_changed_event.fire()
 
-    def _update_scan_channel_map(self, channel_map: typing.Mapping[str, DataItem.DataItem]) -> None:
-        # old_scan_context_channel_map = copy.copy(self.__scan_context_channel_map)
-        self.__scan_context_channel_map.update(channel_map)
+    def data_channels_updated(self) -> None:
         # always fire this even if the map is unchanged; properties (channel enabled) which affect
         # downstream filtering might have changed.
-        # if old_scan_context_channel_map != self.__scan_context_channel_map:
         self.scan_context_data_items_changed_event.fire()
 
     @property

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -29,7 +29,6 @@ from nion.utils import ReferenceCounting
 from nion.utils import Registry
 
 if typing.TYPE_CHECKING:
-    from nion.swift.model import DataItem
     from nion.swift.model import DisplayItem
     from nion.instrumentation import camera_base
     from nion.instrumentation import scan_base

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -829,12 +829,11 @@ def make_scan_display_item_list_model(document_model: DocumentModel.DocumentMode
     def is_scan_context_display_item(display_item: DisplayItem.DisplayItem) -> bool:
         scan_controller = stem_controller.scan_controller
         if scan_controller:
-            data_channels = scan_controller.get_enabled_data_channels()
-            for data_channel in data_channels:
-                if data_channel.is_context:
-                    data_item_channel_reference = document_model.get_data_item_channel_reference(scan_controller.hardware_source_id, data_channel.data_channel_id)
-                    if data_item_channel_reference and data_item_channel_reference.display_item == display_item:
-                        return True
+            data_channel_ids = scan_controller.get_enabled_context_data_channel_ids()
+            for data_channel_id in data_channel_ids:
+                data_item_channel_reference = document_model.get_data_item_channel_reference(scan_controller.hardware_source_id, data_channel_id)
+                if data_item_channel_reference and data_item_channel_reference.display_item == display_item:
+                    return True
         return False
 
     return DisplayItemListModel(document_model, call_soon_threadsafe, "display_items", is_scan_context_display_item, stem_controller.scan_context_data_items_changed_event)

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -832,7 +832,7 @@ def make_scan_display_item_list_model(document_model: DocumentModel.DocumentMode
             data_channels = scan_controller.get_enabled_data_channels()
             for data_channel in data_channels:
                 if data_channel.is_context:
-                    data_item_channel_reference = document_model.get_data_item_channel_reference(scan_controller.hardware_source_id, data_channel.channel_id)
+                    data_item_channel_reference = document_model.get_data_item_channel_reference(scan_controller.hardware_source_id, data_channel.data_channel_id)
                     if data_item_channel_reference and data_item_channel_reference.display_item == display_item:
                         return True
         return False

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -835,11 +835,12 @@ def make_scan_display_item_list_model(document_model: DocumentModel.DocumentMode
     def is_scan_context_display_item(display_item: DisplayItem.DisplayItem) -> bool:
         scan_controller = stem_controller.scan_controller
         if scan_controller:
-            context_data_channels = scan_controller.get_enabled_context_data_channels()
-            for data_channel in context_data_channels:
-                data_item_channel_reference = document_model.get_data_item_channel_reference(scan_controller.hardware_source_id, data_channel.channel_id)
-                if data_item_channel_reference and data_item_channel_reference.display_item == display_item:
-                    return True
+            data_channels = scan_controller.get_enabled_data_channels()
+            for data_channel in data_channels:
+                if data_channel.is_context:
+                    data_item_channel_reference = document_model.get_data_item_channel_reference(scan_controller.hardware_source_id, data_channel.channel_id)
+                    if data_item_channel_reference and data_item_channel_reference.display_item == display_item:
+                        return True
         return False
 
     return DisplayItemListModel(document_model, call_soon_threadsafe, "display_items", is_scan_context_display_item, stem_controller.scan_context_data_items_changed_event)

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -256,8 +256,16 @@ class STEMController(Observable.Observable):
 
     @property
     def scan_controller(self) -> typing.Optional[scan_base.ScanHardwareSource]:
+        # for testing
         if self.__scan_controller:
             return self.__scan_controller
+        # prefer the primary scan_hardware_source. this is implemented a bit funny for
+        # backwards compatibility, with reverse logic.
+        for component in Registry.get_components_by_type("scan_hardware_source"):
+            scan_hardware_source = typing.cast("scan_base.ScanHardwareSource", component)
+            if not scan_hardware_source.scan_device.scan_device_is_secondary:
+                return scan_hardware_source
+        # otherwise return the only registered hardware source
         return typing.cast(typing.Optional["scan_base.ScanHardwareSource"],
                            Registry.get_component("scan_hardware_source"))
 

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -825,13 +825,15 @@ class DisplayItemListModel(Observable.Observable):
                     if graphic.graphic_id == graphic_id:
                         display_item.remove_graphic(graphic).close()
 
+
 def make_scan_display_item_list_model(document_model: DocumentModel.DocumentModel, stem_controller: STEMController, call_soon_threadsafe: typing.Callable[[typing.Callable[..., None]], None]) -> DisplayItemListModel:
     def is_scan_context_display_item(display_item: DisplayItem.DisplayItem) -> bool:
-        scan_controller = stem_controller.scan_controller
-        if scan_controller:
-            data_channel_ids = scan_controller.get_enabled_context_data_channel_ids()
+        # acts as a filter for the display item list model.
+        scan_hardware_source = stem_controller.scan_controller
+        if scan_hardware_source:
+            data_channel_ids = [scan_hardware_source.get_channel_id(channel_index) for channel_index in scan_hardware_source.get_enabled_channel_indexes()]
             for data_channel_id in data_channel_ids:
-                data_item_channel_reference = document_model.get_data_item_channel_reference(scan_controller.hardware_source_id, data_channel_id)
+                data_item_channel_reference = document_model.get_data_item_channel_reference(scan_hardware_source.hardware_source_id, data_channel_id)
                 if data_item_channel_reference and data_item_channel_reference.display_item == display_item:
                     return True
         return False

--- a/nion/instrumentation/test/AcquisitionTestContext.py
+++ b/nion/instrumentation/test/AcquisitionTestContext.py
@@ -22,7 +22,7 @@ class AcquisitionTestContext(TestContext.MemoryProfileContext):
         ScanDevice.run(typing.cast(InstrumentDevice.Instrument, instrument))
         scan_hardware_source = self.setup_scan_hardware_source(instrument)
         camera_hardware_source = self.setup_camera_hardware_source(instrument, camera_exposure, is_eels)
-        HardwareSource.HardwareSourceManager().hardware_sources = []
+        HardwareSource.HardwareSourceManager()._hardware_source_list_model.clear_items()
         HardwareSource.HardwareSourceManager().hardware_source_added_event = Event.Event()
         HardwareSource.HardwareSourceManager().hardware_source_removed_event = Event.Event()
         self.instrument = instrument

--- a/nion/instrumentation/test/CameraControl_test.py
+++ b/nion/instrumentation/test/CameraControl_test.py
@@ -654,49 +654,6 @@ class TestCameraControlClass(unittest.TestCase):
                 hardware_source.abort_playing(sync_timeout=TIMEOUT)
             document_controller.periodic()
 
-    def test_starting_processed_view_initializes_source_region(self):
-        with self.__test_context(is_eels=True) as test_context:
-            document_controller = test_context.document_controller
-            document_model = test_context.document_model
-            hardware_source = test_context.camera_hardware_source
-            self._acquire_one(document_controller, hardware_source)
-            display_item = document_model.get_display_item_for_data_item(document_model.data_items[0])
-            self.assertEqual(len(display_item.graphics), 1)
-            self.assertEqual(display_item.graphics[0].bounds, hardware_source.data_channels[1].processor.bounds)
-
-    def test_changing_processed_bounds_updates_region(self):
-        with self.__test_context(is_eels=True) as test_context:
-            document_controller = test_context.document_controller
-            document_model = test_context.document_model
-            hardware_source = test_context.camera_hardware_source
-            self._acquire_one(document_controller, hardware_source)
-            new_bounds = (0.45, 0.2), (0.1, 0.6)
-            hardware_source.data_channels[1].processor.bounds = new_bounds
-            display_item = document_model.get_display_item_for_data_item(document_model.data_items[0])
-            self.assertEqual(display_item.graphics[0].bounds, new_bounds)
-
-    def test_changing_region_on_processed_view_updates_processor(self):
-        with self.__test_context(is_eels=True) as test_context:
-            document_controller = test_context.document_controller
-            document_model = test_context.document_model
-            hardware_source = test_context.camera_hardware_source
-            self._acquire_one(document_controller, hardware_source)
-            new_bounds = (0.45, 0.2), (0.1, 0.6)
-            display_item = document_model.get_display_item_for_data_item(document_model.data_items[0])
-            display_item.graphics[0].bounds = new_bounds
-            self.assertEqual(hardware_source.data_channels[1].processor.bounds, new_bounds)
-
-    def test_restarting_processed_view_recreates_region_after_it_has_been_deleted(self):
-        with self.__test_context(is_eels=True) as test_context:
-            document_controller = test_context.document_controller
-            document_model = test_context.document_model
-            hardware_source = test_context.camera_hardware_source
-            self._acquire_one(document_controller, hardware_source)
-            display_item = document_model.get_display_item_for_data_item(document_model.data_items[0])
-            display_item.remove_graphic(display_item.graphics[0]).close()
-            self._acquire_one(document_controller, hardware_source)
-            self.assertEqual(display_item.graphics[0].bounds, hardware_source.data_channels[1].processor.bounds)
-
     def test_acquiring_eels_sets_signal_type_for_both_copies(self):
         # assumes EELS camera produces two data items
         with self.__test_context(is_eels=True) as test_context:

--- a/nion/instrumentation/test/HardwareSource_test.py
+++ b/nion/instrumentation/test/HardwareSource_test.py
@@ -241,6 +241,12 @@ class ScanHardwareSource(HardwareSource.ConcreteHardwareSource):
         self.blanked = False
         self.positioned = False
 
+    def get_channel_count(self):
+        return 2
+
+    def get_channel_id(self, channel_index):
+        return "ab"[channel_index]
+
     @property
     def scanning(self):
         return self.scanning_ref[0]

--- a/nion/instrumentation/test/HardwareSource_test.py
+++ b/nion/instrumentation/test/HardwareSource_test.py
@@ -107,7 +107,7 @@ class LinePlotHardwareSource(HardwareSource.ConcreteHardwareSource):
         super().__init__("described_hardware_source", "DescribedHardwareSource")
         self.add_data_channel()
         if processed:
-            self.add_channel_processor(0, HardwareSource.SumProcessor(Geometry.FloatRect.unit_rect()))
+            self.add_channel_processor(0, HardwareSource.SumProcessor())
         self.sleep = sleep
         self.shape = shape
         self.exposure = 0.0
@@ -124,7 +124,7 @@ class SummedHardwareSource(HardwareSource.ConcreteHardwareSource):
     def __init__(self, sleep=0.05):
         super().__init__("summed_hardware_source", "SummedHardwareSource")
         self.add_data_channel()
-        self.add_channel_processor(0, HardwareSource.SumProcessor(Geometry.FloatRect.unit_rect()))
+        self.add_channel_processor(0, HardwareSource.SumProcessor())
         self.sleep = sleep
         self.image = numpy.zeros((256, 256))
         self.exposure = 0.0

--- a/nion/instrumentation/test/HardwareSource_test.py
+++ b/nion/instrumentation/test/HardwareSource_test.py
@@ -810,7 +810,7 @@ class TestHardwareSourceClass(unittest.TestCase):
             data_item = DataItem.DataItem(data)
             document_model.append_data_item(data_item)
             document_model.setup_channel(document_model.make_data_item_reference_key(hardware_source.hardware_source_id, "a"), data_item)
-            hardware_source.data_channel_list_model.items[0].update(DataAndMetadata.new_data_and_metadata(data), "complete", None, None, None, None)
+            hardware_source._data_channel_manager._test_update_data_channel(DataAndMetadata.new_data_and_metadata(data))
             hardware_source.sleep = 0.20
             hardware_source.start_playing()
             time.sleep(0.02)

--- a/nion/instrumentation/test/HardwareSource_test.py
+++ b/nion/instrumentation/test/HardwareSource_test.py
@@ -810,7 +810,7 @@ class TestHardwareSourceClass(unittest.TestCase):
             data_item = DataItem.DataItem(data)
             document_model.append_data_item(data_item)
             document_model.setup_channel(document_model.make_data_item_reference_key(hardware_source.hardware_source_id, "a"), data_item)
-            hardware_source.data_channels[0].update(DataAndMetadata.new_data_and_metadata(data), "complete", None, None, None, None)
+            hardware_source.data_channel_list_model.items[0].update(DataAndMetadata.new_data_and_metadata(data), "complete", None, None, None, None)
             hardware_source.sleep = 0.20
             hardware_source.start_playing()
             time.sleep(0.02)

--- a/nion/instrumentation/test/MultiAcquire_test.py
+++ b/nion/instrumentation/test/MultiAcquire_test.py
@@ -207,8 +207,8 @@ class TestMultiAcquire(unittest.TestCase):
                                 camera_data_channel = MultiAcquire.CameraDataChannel(document_model, camera_hardware_source.display_name, grab_synchronized_info,
                                                                                      multi_acquire_parameters, multi_acquire_settings, current_parameters_index,
                                                                                      stack_metadata_keys=[['hardware_source', 'binning']])
-                                enabled_channels = scan_hardware_source.get_enabled_channels()
-                                enabled_channel_names = [scan_hardware_source.data_channels[i].name for i in enabled_channels]
+                                enabled_channels = scan_hardware_source.get_enabled_channel_indexes()
+                                enabled_channel_names = [scan_hardware_source.get_channel_name(i) for i in enabled_channels]
                                 scan_data_channel = MultiAcquire.ScanDataChannel(document_model, enabled_channel_names, grab_synchronized_info,
                                                                                  multi_acquire_parameters, multi_acquire_settings, current_parameters_index)
                                 camera_data_channel.start()
@@ -327,8 +327,8 @@ class TestMultiAcquire(unittest.TestCase):
                 camera_data_channel = MultiAcquire.CameraDataChannel(document_model, camera_hardware_source.display_name, grab_synchronized_info,
                                                                      multi_acquire_parameters, multi_acquire_settings, current_parameters_index,
                                                                      stack_metadata_keys=[['hardware_source', 'defocus']])
-                enabled_channels = scan_hardware_source.get_enabled_channels()
-                enabled_channel_names = [scan_hardware_source.data_channels[i].name for i in enabled_channels]
+                enabled_channels = scan_hardware_source.get_enabled_channel_indexes()
+                enabled_channel_names = [scan_hardware_source.get_channel_name(i) for i in enabled_channels]
                 scan_data_channel = MultiAcquire.ScanDataChannel(document_model, enabled_channel_names, grab_synchronized_info,
                                                                  multi_acquire_parameters, multi_acquire_settings, current_parameters_index)
                 camera_data_channel.start()

--- a/nion/instrumentation/test/ScanControl_test.py
+++ b/nion/instrumentation/test/ScanControl_test.py
@@ -373,7 +373,7 @@ class TestScanControlClass(unittest.TestCase):
                 self.assertEqual(scan_hardware_source.stem_controller.GetVal("EHT"), Metadata.get_metadata_value(metadata_source, "stem.high_tension"))
                 self.assertEqual(scan_hardware_source.stem_controller.GetVal("C10"), Metadata.get_metadata_value(metadata_source, "stem.defocus"))
                 self.assertEqual(channel_index, Metadata.get_metadata_value(metadata_source, "stem.scan.channel_index"))
-                self.assertEqual(scan_hardware_source.get_channel_state(channel_index % 4).channel_id + "_subscan", Metadata.get_metadata_value(metadata_source, "stem.scan.channel_id"))
+                self.assertEqual(scan_hardware_source.get_channel_state(channel_index % 4).channel_id, Metadata.get_metadata_value(metadata_source, "stem.scan.channel_id"))
                 self.assertEqual(scan_hardware_source.get_channel_state(channel_index % 4).name + " SubScan", Metadata.get_metadata_value(metadata_source, "stem.scan.channel_name"))
                 self.assertEqual(0.0, Metadata.get_metadata_value(metadata_source, "stem.scan.center_x_nm"))
                 self.assertEqual(0.0, Metadata.get_metadata_value(metadata_source, "stem.scan.center_x_nm"))

--- a/nion/instrumentation/test/ScanControl_test.py
+++ b/nion/instrumentation/test/ScanControl_test.py
@@ -372,9 +372,9 @@ class TestScanControlClass(unittest.TestCase):
                 self.assertNotIn("autostem", metadata_source.metadata["hardware_source"])
                 self.assertEqual(scan_hardware_source.stem_controller.GetVal("EHT"), Metadata.get_metadata_value(metadata_source, "stem.high_tension"))
                 self.assertEqual(scan_hardware_source.stem_controller.GetVal("C10"), Metadata.get_metadata_value(metadata_source, "stem.defocus"))
-                self.assertEqual(channel_index, Metadata.get_metadata_value(metadata_source, "stem.scan.channel_index"))
+                self.assertEqual(channel_index % 4, Metadata.get_metadata_value(metadata_source, "stem.scan.channel_index"))
                 self.assertEqual(scan_hardware_source.get_channel_state(channel_index % 4).channel_id, Metadata.get_metadata_value(metadata_source, "stem.scan.channel_id"))
-                self.assertEqual(scan_hardware_source.get_channel_state(channel_index % 4).name + " SubScan", Metadata.get_metadata_value(metadata_source, "stem.scan.channel_name"))
+                self.assertEqual(scan_hardware_source.get_channel_state(channel_index % 4).name + " Subscan", Metadata.get_metadata_value(metadata_source, "stem.scan.channel_name"))
                 self.assertEqual(0.0, Metadata.get_metadata_value(metadata_source, "stem.scan.center_x_nm"))
                 self.assertEqual(0.0, Metadata.get_metadata_value(metadata_source, "stem.scan.center_x_nm"))
                 self.assertAlmostEqual(frame_parameters.size[0] * frame_parameters.subscan_fractional_size[0] * frame_parameters.size[1] * frame_parameters.subscan_fractional_size[1] * frame_parameters.pixel_time_us / 1E6, Metadata.get_metadata_value(metadata_source, "stem.scan.frame_time"))
@@ -1450,9 +1450,9 @@ class TestScanControlClass(unittest.TestCase):
             scan_frame_parameters["ac_line_sync"] = False
             scan_frame_parameters["ac_frame_sync"] = False
             # this tests an issue for a race condition where thread for record task isn't started before the task
-            # is canceled, resulting in the close waiting for the thread and the thread waiting for the acquire.
+            # is canceled, resulting in the close waiting for the thread and the thread waiting to acquire.
             # this reduces the problem, but it's still possible that during external sync, the acquisition starts
-            # before being canceled and must timeout.
+            # before being canceled and must time out.
             with contextlib.closing(hardware_source_facade.create_record_task(scan_frame_parameters)) as task:
                 pass
 

--- a/nion/instrumentation/test/SynchronizedAcquisition_test.py
+++ b/nion/instrumentation/test/SynchronizedAcquisition_test.py
@@ -980,7 +980,7 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
                     si_data_item = data_item
                 if "Spectrum Image" in data_item.title and "HAADF" in data_item.title:
                     si_haadf_data_item = data_item
-                if "SubScan" in data_item.title:
+                if "Subscan" in data_item.title:
                     subscan_data_item = data_item
             self.assertIsNotNone(si_data_item)
             self.assertIsNotNone(si_haadf_data_item)

--- a/nion/instrumentation/test/SynchronizedAcquisition_test.py
+++ b/nion/instrumentation/test/SynchronizedAcquisition_test.py
@@ -605,7 +605,7 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
             test_context.instrument.sample_index = 2  # use CTS sample, custom position chosen using view mode in Swift
             camera_hardware_source = test_context.camera_hardware_source
             self._acquire_one(document_controller, scan_hardware_source)
-            scan_hardware_source.drift_channel_id = scan_hardware_source.data_channels[0].channel_id
+            scan_hardware_source.drift_enabled = True
             scan_hardware_source.drift_region = Geometry.FloatRect.from_center_and_size(Geometry.FloatPoint(0.6554, 0.2932), Geometry.FloatSize(0.15, 0.15))
             document_controller.periodic()
             scan_frame_parameters = scan_hardware_source.get_current_frame_parameters()
@@ -635,7 +635,7 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
             scan_hardware_source = test_context.scan_hardware_source
             camera_hardware_source = test_context.camera_hardware_source
             self._acquire_one(document_controller, scan_hardware_source)
-            scan_hardware_source.drift_channel_id = scan_hardware_source.data_channels[0].channel_id
+            scan_hardware_source.drift_enabled = True
             scan_hardware_source.drift_region = Geometry.FloatRect.from_tlhw(0.25, 0.25, 0.5, 0.5)
             document_controller.periodic()
             display_item = document_model.display_items[-1]
@@ -673,7 +673,7 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
             scan_hardware_source = test_context.scan_hardware_source
             camera_hardware_source = test_context.camera_hardware_source
             self._acquire_one(document_controller, scan_hardware_source)
-            scan_hardware_source.drift_channel_id = scan_hardware_source.data_channels[0].channel_id
+            scan_hardware_source.drift_enabled = True
             scan_hardware_source.drift_region = Geometry.FloatRect.from_tlhw(0.25, 0.25, 0.5, 0.5)
             document_controller.periodic()
             display_item = document_model.display_items[-1]
@@ -715,7 +715,7 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
             test_context.instrument.sample_index = 2  # use CTS sample, custom position chosen using view mode in Swift
             drift_tracker = scan_hardware_source.drift_tracker
             self._acquire_one(document_controller, scan_hardware_source)
-            scan_hardware_source.drift_channel_id = scan_hardware_source.data_channels[0].channel_id
+            scan_hardware_source.drift_enabled = True
             scan_hardware_source.drift_region = Geometry.FloatRect.from_center_and_size(Geometry.FloatPoint(0.6554, 0.2932), Geometry.FloatSize(0.15, 0.15))
             document_controller.periodic()
             scan_frame_parameters = scan_hardware_source.get_current_frame_parameters()
@@ -750,7 +750,7 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
             test_context.instrument.sample_index = 2  # use CTS sample, custom position chosen using view mode in Swift
             drift_tracker = scan_hardware_source.drift_tracker
             self._acquire_one(document_controller, scan_hardware_source)
-            scan_hardware_source.drift_channel_id = scan_hardware_source.data_channels[0].channel_id
+            scan_hardware_source.drift_enabled = True
             scan_hardware_source.drift_region = Geometry.FloatRect.from_center_and_size(Geometry.FloatPoint(0.6554, 0.2932), Geometry.FloatSize(0.15, 0.15))
             rotation = math.radians(30)  # note: this is only rotating the drift region, not the overall sample
             scan_hardware_source.drift_rotation = rotation
@@ -791,7 +791,7 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
                 test_context.instrument.sample_index = 2  # use CTS sample, custom position chosen using view mode in Swift
                 drift_tracker = scan_hardware_source.drift_tracker
                 self._acquire_one(document_controller, scan_hardware_source)
-                scan_hardware_source.drift_channel_id = scan_hardware_source.data_channels[0].channel_id
+                scan_hardware_source.drift_enabled = True
                 scan_hardware_source.drift_region = Geometry.FloatRect.from_center_and_size(Geometry.FloatPoint(0.6554, 0.2932), Geometry.FloatSize(0.15, 0.15))
                 document_controller.periodic()
                 # Change the default parameters (64 px and 16 us) to something different

--- a/nion/instrumentation/test/SynchronizedAcquisition_test.py
+++ b/nion/instrumentation/test/SynchronizedAcquisition_test.py
@@ -924,7 +924,7 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
                     si_data_item = data_item
                 if "Spectrum Image" in data_item.title and "HAADF" in data_item.title:
                     si_haadf_data_item = data_item
-                if "SubScan" in data_item.title:
+                if "Subscan" in data_item.title:
                     subscan_data_item = data_item
             self.assertIsNotNone(si_data_item)
             self.assertIsNotNone(si_haadf_data_item)
@@ -1028,7 +1028,7 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
                     si_data_item = data_item
                 if "Spectrum Image" in data_item.title and "HAADF" in data_item.title:
                     si_haadf_data_item = data_item
-                if "SubScan" in data_item.title:
+                if "Subscan" in data_item.title:
                     subscan_data_item = data_item
             self.assertIsNotNone(si_data_item)
             self.assertIsNotNone(si_haadf_data_item)

--- a/nionswift_plugin/nion_instrumentation_ui/AcquisitionPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/AcquisitionPanel.py
@@ -1424,7 +1424,7 @@ def build_synchronized_device_data_stream(scan_hardware_source: scan_base.ScanHa
     # construct the channel names.
     op = _("Synchronized")
     channel_names: typing.Dict[Acquisition.Channel, str] = dict()
-    for c in scan_hardware_source.get_enabled_channels():
+    for c in scan_hardware_source.get_enabled_channel_indexes():
         channel_state = scan_hardware_source.get_channel_state(c)
         channel_index_segment = str(scan_hardware_source.get_channel_index(channel_state.channel_id))
         channel_names[Acquisition.Channel(scan_hardware_source.hardware_source_id, channel_index_segment)] = f"{op} {channel_state.name}"
@@ -1762,7 +1762,7 @@ def build_scan_device_data_stream(scan_hardware_source: scan_base.ScanHardwareSo
     collector = Acquisition.StackedDataStream(collectors)
     # construct the channel names.
     channel_names: typing.Dict[Acquisition.Channel, str] = dict()
-    for c in scan_hardware_source.get_enabled_channels():
+    for c in scan_hardware_source.get_enabled_channel_indexes():
         channel_state = scan_hardware_source.get_channel_state(c)
         channel_index_segment = str(scan_hardware_source.get_channel_index(channel_state.channel_id))
         channel_names[Acquisition.Channel(scan_hardware_source.hardware_source_id, channel_index_segment)] = channel_state.name

--- a/nionswift_plugin/nion_instrumentation_ui/CameraControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/CameraControlPanel.py
@@ -349,11 +349,8 @@ class CameraControlStateController:
         if callable(self.on_log_messages):
             self.on_log_messages(messages, data_elements)
 
-    def __data_channel_state_changed(self, data_channel: HardwareSource.DataChannel) -> None:
-        if data_channel.is_started and data_channel.state:
-            self.acquisition_state_model.value = data_channel.state
-        else:
-            self.acquisition_state_model.value = "error" if data_channel.is_error else "stopped"
+    def __data_channel_state_changed(self, data_channel_event_args: HardwareSource.DataChannelEventArgs) -> None:
+        self.acquisition_state_model.value = data_channel_event_args.data_channel_state
 
 
 class IconCanvasItem(CanvasItem.TextButtonCanvasItem):

--- a/nionswift_plugin/nion_instrumentation_ui/MultiAcquirePanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/MultiAcquirePanel.py
@@ -399,7 +399,7 @@ class MultiAcquirePanelDelegate:
                         camera_data_channel = MultiAcquire.CameraDataChannel(document_model, camera.display_name, grab_synchronized_info,
                                                                              multi_acquire_parameters, multi_acquire_settings, current_parameters_index,
                                                                              stack_metadata_keys=stack_metadata_keys)
-                        enabled_channels = scan_controller.get_enabled_channels()
+                        enabled_channels = scan_controller.get_enabled_channel_indexes()
                         enabled_channel_names = [scan_controller.get_channel_name(i) or str() for i in enabled_channels]
                         scan_data_channel = MultiAcquire.ScanDataChannel(document_model, enabled_channel_names, grab_synchronized_info,
                                                                          multi_acquire_parameters, multi_acquire_settings, current_parameters_index)

--- a/nionswift_plugin/nion_instrumentation_ui/MultiAcquirePanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/MultiAcquirePanel.py
@@ -400,7 +400,7 @@ class MultiAcquirePanelDelegate:
                                                                              multi_acquire_parameters, multi_acquire_settings, current_parameters_index,
                                                                              stack_metadata_keys=stack_metadata_keys)
                         enabled_channels = scan_controller.get_enabled_channels()
-                        enabled_channel_names = [scan_controller.data_channels[i].name or str() for i in enabled_channels]
+                        enabled_channel_names = [scan_controller.get_channel_name(i) or str() for i in enabled_channels]
                         scan_data_channel = MultiAcquire.ScanDataChannel(document_model, enabled_channel_names, grab_synchronized_info,
                                                                          multi_acquire_parameters, multi_acquire_settings, current_parameters_index)
                         camera_data_channel.start()

--- a/nionswift_plugin/nion_instrumentation_ui/ScanAcquisition.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanAcquisition.py
@@ -106,7 +106,7 @@ class ScanAcquisitionController:
         camera_frame_parameters.processing = processing.value.processing_id
 
         channel_names: typing.Dict[Acquisition.Channel, str] = dict()
-        for c in scan_hardware_source.get_enabled_channels():
+        for c in scan_hardware_source.get_enabled_channel_indexes():
             channel_state = scan_hardware_source.get_channel_state(c)
             channel_index_segment = str(scan_hardware_source.get_channel_index(channel_state.channel_id))
             channel_names[Acquisition.Channel(scan_hardware_source.hardware_source_id, channel_index_segment)] = channel_state.name

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -663,11 +663,10 @@ class ScanControlStateController:
         data_channel_state_changed = self.on_data_channel_state_changed
         if callable(data_channel_state_changed):
             data_channel_state_changed(channel_index, channel_id, name, enabled)
-            subscan_channel_index, subscan_channel_id, subscan_channel_name, subscan_channel_variant = self.__scan_hardware_source.get_subscan_channel_info(channel_index, channel_id, name)
             data_channel_state_changed(
-                subscan_channel_index + (self.__scan_hardware_source.channel_count if subscan_channel_variant else 0),
-                subscan_channel_id + ("_" + subscan_channel_variant if subscan_channel_variant else ""),
-                subscan_channel_name,
+                channel_index + self.__scan_hardware_source.channel_count,
+                channel_id + "_subscan",
+                name + " " + _("Subscan"),
                 enabled)
         was_any_channel_enabled = any(self.__channel_enabled)
         self.__channel_enabled[channel_index] = enabled

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -666,8 +666,12 @@ class ScanControlStateController:
         data_channel_state_changed = self.on_data_channel_state_changed
         if callable(data_channel_state_changed):
             data_channel_state_changed(channel_index, channel_id, name, enabled)
-            subscan_channel_index, subscan_channel_id, subscan_channel_name = self.__scan_hardware_source.get_subscan_channel_info(channel_index, channel_id, name)
-            data_channel_state_changed(subscan_channel_index, subscan_channel_id, subscan_channel_name, enabled)
+            subscan_channel_index, subscan_channel_id, subscan_channel_name, subscan_channel_variant = self.__scan_hardware_source.get_subscan_channel_info(channel_index, channel_id, name)
+            data_channel_state_changed(
+                subscan_channel_index + (self.__scan_hardware_source.channel_count if subscan_channel_variant else 0),
+                subscan_channel_id + ("_" + subscan_channel_variant if subscan_channel_variant else ""),
+                subscan_channel_name,
+                enabled)
         was_any_channel_enabled = any(self.__channel_enabled)
         self.__channel_enabled[channel_index] = enabled
         is_any_channel_enabled = any(self.__channel_enabled)

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -643,14 +643,11 @@ class ScanControlStateController:
             self.__captured_xdatas_available_listener = None
         self.queue_task(self.__update_buttons)
 
-    def __data_channel_state_changed(self, data_channel: HardwareSource.DataChannel) -> None:
+    def __data_channel_state_changed(self, data_channel_event_args: HardwareSource.DataChannelEventArgs) -> None:
         # the value (dict) does not get copied; so copy it here.
         acquisition_states = copy.deepcopy(self.acquisition_state_model.value) or dict()
-        channel_id = data_channel.channel_id or "unknown"
-        if data_channel.is_started and data_channel.state:
-            acquisition_states[channel_id] = data_channel.state
-        else:
-            acquisition_states[channel_id] = "error" if data_channel.is_error else "stopped"
+        channel_id = data_channel_event_args.channel_id or "unknown"
+        acquisition_states[channel_id] = data_channel_event_args.data_channel_state
         self.acquisition_state_model.value = acquisition_states
 
     def __probe_state_changed(self, probe_state: str, probe_position: typing.Optional[Geometry.FloatPoint]) -> None:

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -2013,7 +2013,6 @@ def register_scan_panel(hardware_source: HardwareSource.HardwareSource) -> None:
 
         name = hardware_source.display_name + " " + _("Scan Control")
         panel_properties = {"hardware_source_id": hardware_source.hardware_source_id}
-        Workspace.WorkspaceManager().register_panel(ScanControlPanel, panel_id, name, ["left", "right"], "left", panel_properties)
 
         panel_type = hardware_source.features.get("panel_type")
         if not panel_type:

--- a/nionswift_plugin/nion_instrumentation_ui/VideoControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/VideoControlPanel.py
@@ -365,7 +365,7 @@ class VideoSourcePanel(Panel.Panel):
 
         self.__hardware_source_widgets: typing.Dict[str, VideoSourceWidget] = dict()
 
-        hardware_sources = HardwareSource.HardwareSourceManager().hardware_sources
+        hardware_sources = list(HardwareSource.HardwareSourceManager().hardware_sources)
         hardware_sources.sort(key=lambda hardware_source: hardware_source.display_name or _("Unknown"))
 
         def hardware_source_added(hardware_source: HardwareSource.HardwareSource) -> None:

--- a/nionswift_plugin/nion_instrumentation_ui/VideoControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/VideoControlPanel.py
@@ -171,11 +171,8 @@ class VideoSourceStateController:
     def __acquisition_state_changed(self, is_playing: bool) -> None:
         self.queue_task(self.__update_buttons)
 
-    def __data_channel_state_changed(self, data_channel: HardwareSource.DataChannel) -> None:
-        if data_channel.is_started and data_channel.state:
-            self.acquisition_state_model.value = data_channel.state
-        else:
-            self.acquisition_state_model.value = "error" if data_channel.is_error else "stopped"
+    def __data_channel_state_changed(self, data_channel_event_args: HardwareSource.DataChannelEventArgs) -> None:
+        self.acquisition_state_model.value = data_channel_event_args.data_channel_state
 
 
 class VideoDisplayPanelController:


### PR DESCRIPTION
- Fix issue where acquisition graphics would not appear on new channels. Test.
- Fix more acquisition graphic edge cases: graphics only on enabled context displays. Test.
- Add list listener utility and use to to handle onerous aspects of data channel.
- Additional refactoring to limit use of data channels; also fix API view task with multiple channels.
- Eliminate data channel methods from base hardware source. Minimize data channel use further.
- Simplify handling of data channels updated. Eliminates more data_channels usage.
- Eliminate summing-crop on EELS (now just summing). Remove obsolete tests.
- Use stricter channel_id, no suffixes. Use variant as adjunct.
- Rename 'channel_override' to 'channel_variant'. Eliminate data_channels accessor.
- Separate data channel management to its own class DataChannelManager.
- WIP: Begin isolating data channel class.
- Several small refactorings to further isolate data channel.
- Add mechanism to override channel mapping via scan module.
- Improve handling of scan calibrations from device.
- Remove spurious register_panel (prevented custom panels from working properly).
- Add mechanism via DataChannelDelegate for scan modules to indicate viewable data channels.
- Add a mechanism to prefer the primary scan_controller in the STEM controller.
