### PR TITLE
YA: fix broken scan dialog

### DIFF
--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -458,7 +458,7 @@ class ScanControlStateController:
 
     # must be called on ui thread
     def handle_settings_button_clicked(self, api_broker: typing.Any) -> None:
-        self.__scan_hardware_source.open_configuration_interface(api_broker)
+        self.__scan_hardware_source.scan_device.open_configuration_interface(api_broker)
 
     # must be called on ui thread
     def handle_shift_click(self, hardware_source_id: str, mouse_position: Geometry.FloatPoint, camera_shape: DataAndMetadata.Shape2dType, logger: logging.Logger) -> bool:


### PR DESCRIPTION
Minor typo. This has been broken since 0.21.X. The method open_configuration_interface should belong to ScanDevice, as also used in usim scandevice example.