### PR TITLE
Make console startup lines self-sufficient.

### DIFF
--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -1711,7 +1711,8 @@ class ConsoleStartupInfo:
 class ConsoleStartupComponent:
     def get_console_startup_info(self, logger: logging.Logger) -> ConsoleStartupInfo:
         logger.info("STEM Controller Console Startup (stem_controller)")
-        return ConsoleStartupInfo("stem_controller", ["stem_controller = Registry.get_component('stem_controller')"], None)
+        return ConsoleStartupInfo("stem_controller", ["from nion.utils import Registry",
+                                                      "stem_controller = Registry.get_component('stem_controller')"], None)
 
 
 Registry.register_component(ConsoleStartupComponent(), {"console-startup"})


### PR DESCRIPTION
I think this is good practice in general, but is a required change for https://github.com/nion-software/nionswift/pull/1082, because that does not guarantee an order for the console startup code lines anymore.
So if the startup code registered here gets executed before the default one from `ConsoleDialog.py`, the code here will fail because of the missing `Registry` import.
This change makes the startup code registered here independent from other code that migh or might not run first.