### PR TITLE
Restructure acquisition test context to more closely match regular launch

### DIFF
--- a/nion/instrumentation/camera_base.py
+++ b/nion/instrumentation/camera_base.py
@@ -3491,6 +3491,7 @@ def run(configuration_location: pathlib.Path) -> None:
             camera_hardware_source = component.hardware_source
             Registry.unregister_component(camera_hardware_source)
             HardwareSource.HardwareSourceManager().unregister_hardware_source(camera_hardware_source)
+            camera_hardware_source.close()
 
     global _component_registered_listener
     global _component_unregistered_listener

--- a/nion/instrumentation/camera_base.py
+++ b/nion/instrumentation/camera_base.py
@@ -3501,3 +3501,14 @@ def run(configuration_location: pathlib.Path) -> None:
 
     for component in Registry.get_components_by_type("camera_module"):
         component_registered(component, {"camera_module"})
+
+
+def stop() -> None:
+    global _component_registered_listener
+    global _component_unregistered_listener
+    if _component_registered_listener:
+        _component_registered_listener.close()
+    if _component_unregistered_listener:
+        _component_unregistered_listener.close()
+    _component_registered_listener = None
+    _component_unregistered_listener = None

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -2802,7 +2802,7 @@ def run(configuration_location: pathlib.Path) -> None:
             scan_module = typing.cast(ScanModule, component)
             stem_controller = find_stem_controller(scan_module.stem_controller_id)
             if not stem_controller:
-                print("STEM Controller (" + component.stem_controller_id + ") for (" + component.scan_device_id + ") not found. Using proxy.")
+                print("STEM Controller (" + component.stem_controller_id + ") for (" + component.device.scan_device_id + ") not found. Using proxy.")
                 stem_controller = STEMController.STEMController()
             scan_hardware_source = ConcreteScanHardwareSource(stem_controller, scan_module.device, scan_module.settings, configuration_location, scan_module.panel_type)
             if scan_module.data_channel_delegate:

--- a/nion/instrumentation/test/AcquisitionTestContext.py
+++ b/nion/instrumentation/test/AcquisitionTestContext.py
@@ -39,9 +39,9 @@ class AcquisitionTestContext(TestContext.MemoryProfileContext):
         HardwareSource.HardwareSourceManager()._hardware_source_list_model.clear_items()
         HardwareSource.HardwareSourceManager().hardware_source_added_event = Event.Event()
         HardwareSource.HardwareSourceManager().hardware_source_removed_event = Event.Event()
-        scan_hardware_source = self.setup_scan_hardware_source(configuration.instrument, configuration.scan_module.device, configuration.scan_module.settings)
-        self._ronchigram_camera_hardware_source = self.setup_camera_hardware_source(configuration.instrument_id, configuration.ronchigram_camera_device, configuration.ronchigram_camera_settings, camera_exposure, False)
-        self._eels_camera_hardware_source = self.setup_camera_hardware_source(configuration.instrument_id, configuration.eels_camera_device, configuration.eels_camera_settings, camera_exposure, True)
+        scan_hardware_source = self.__setup_scan_hardware_source(configuration.instrument, configuration.scan_module.device, configuration.scan_module.settings)
+        self._ronchigram_camera_hardware_source = self.__setup_camera_hardware_source(configuration.instrument_id, configuration.ronchigram_camera_device, configuration.ronchigram_camera_settings, camera_exposure, False)
+        self._eels_camera_hardware_source = self.__setup_camera_hardware_source(configuration.instrument_id, configuration.eels_camera_device, configuration.eels_camera_settings, camera_exposure, True)
         self.instrument = configuration.instrument
         self.scan_hardware_source = scan_hardware_source
         self.camera_hardware_source = self._eels_camera_hardware_source if is_eels else self._ronchigram_camera_hardware_source
@@ -81,14 +81,14 @@ class AcquisitionTestContext(TestContext.MemoryProfileContext):
     def push(self, ex: typing.Any) -> None:
         self.__exit_stack.append(ex)
 
-    def setup_scan_hardware_source(self, stem_controller: stem_controller.STEMController, scan_device: scan_base.ScanDevice, scan_settings: scan_base.ScanSettingsProtocol) -> scan_base.ScanHardwareSource:
+    def __setup_scan_hardware_source(self, stem_controller: stem_controller.STEMController, scan_device: scan_base.ScanDevice, scan_settings: scan_base.ScanSettingsProtocol) -> scan_base.ScanHardwareSource:
         scan_hardware_source = scan_base.ConcreteScanHardwareSource(stem_controller, scan_device, scan_settings, None)
         setattr(scan_device, "hardware_source", scan_hardware_source)
         Registry.register_component(scan_hardware_source, {"hardware_source", "scan_hardware_source"})  # allows stem controller to find scan controller
         HardwareSource.HardwareSourceManager().register_hardware_source(scan_hardware_source)
         return scan_hardware_source
 
-    def setup_camera_hardware_source(self, instrument_id: str, camera_device: camera_base.CameraDevice3, camera_settings: camera_base.CameraSettings, camera_exposure: float, is_eels: bool) -> camera_base.CameraHardwareSource:
+    def __setup_camera_hardware_source(self, instrument_id: str, camera_device: camera_base.CameraDevice3, camera_settings: camera_base.CameraSettings, camera_exposure: float, is_eels: bool) -> camera_base.CameraHardwareSource:
         camera_type = "eels" if is_eels else "ronchigram"
         camera_hardware_source = camera_base.CameraHardwareSource3(instrument_id, camera_device, camera_settings, None, None)
         if is_eels:

--- a/nion/instrumentation/test/AcquisitionTestContext.py
+++ b/nion/instrumentation/test/AcquisitionTestContext.py
@@ -67,8 +67,8 @@ class AcquisitionTestContext(TestContext.MemoryProfileContext):
             ex.close()
         stem_controller.unregister_event_loop()
         self.configuration.stop()
-        HardwareSource.HardwareSourceManager().close()
-        HardwareSource.stop()
+        from nionswift_plugin import nion_instrumentation_ui
+        nion_instrumentation_ui.stop()
         super().close()
 
     def push(self, ex: typing.Any) -> None:

--- a/nion/instrumentation/video_base.py
+++ b/nion/instrumentation/video_base.py
@@ -306,3 +306,14 @@ def run() -> None:
 
     for component in Registry.get_components_by_type("video_device"):
         component_registered(component, {"video_device"})
+
+
+def stop() -> None:
+    global _component_registered_listener
+    global _component_unregistered_listener
+    if _component_registered_listener:
+        _component_registered_listener.close()
+    if _component_unregistered_listener:
+        _component_unregistered_listener.close()
+    _component_registered_listener = None
+    _component_unregistered_listener = None

--- a/nionswift_plugin/nion_instrumentation_ui/MultipleShiftEELSAcquire.py
+++ b/nionswift_plugin/nion_instrumentation_ui/MultipleShiftEELSAcquire.py
@@ -579,3 +579,8 @@ def run() -> None:
                                      disp_name,
                                      ["left", "right"],
                                      "left")
+
+
+def stop() -> None:
+    workspace_manager = Workspace.WorkspaceManager()
+    workspace_manager.unregister_panel(name+"-control-panel")

--- a/nionswift_plugin/nion_instrumentation_ui/__init__.py
+++ b/nionswift_plugin/nion_instrumentation_ui/__init__.py
@@ -56,3 +56,19 @@ def run() -> None:
         ScanControlPanel.run()
         MultipleShiftEELSAcquire.run()
         VideoControlPanel.run()
+
+
+def stop() -> None:
+    global configuration_location
+    if configuration_location:
+        VideoControlPanel.stop()
+        MultipleShiftEELSAcquire.stop()
+        ScanControlPanel.stop()
+        CameraControlPanel.stop()
+        video_base.stop()
+        scan_base.stop()
+        camera_base.stop()
+        DriftTracker.stop()
+        HardwareSource.stop()
+        HardwareSource.HardwareSourceManager().close()
+        configuration_location = None


### PR DESCRIPTION
- **Make setup methods private.**
- **Ensure camera hardware source is closed at unregister, like scan.**
- **Restructure acquisition test context to more closely match regular launch.**
- **Fix typo when missing STEM controller.**
- **Additional restructuing to run/stop more consistently.**
- **Fix race conditions when writing settings file. Revealed in new tests.**

These have no effect on functionality, although downstream clients of instrumentation kit may need slight run/stop adjustments and/or test configuration changes.