### PR TITLE
Fix issue applying frame parameters when using start playing action.

### DIFF
--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -1311,6 +1311,7 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
                 frame_parameters = self.__settings.get_frame_parameters_from_dict(typing.cast(typing.Dict[str, typing.Any], kwargs["frame_parameters"]))
             self.set_current_frame_parameters(frame_parameters)
         elif len(args) == 1 and isinstance(args[0], dict):
+            # positional argument handling is only for backward compatibility and could be removed.
             frame_parameters = self.__settings.get_frame_parameters_from_dict(args[0])
             self.set_current_frame_parameters(frame_parameters)
         super().start_playing(*args, **kwargs)

--- a/nionswift_plugin/nion_instrumentation_ui/HardwareSourceActions.py
+++ b/nionswift_plugin/nion_instrumentation_ui/HardwareSourceActions.py
@@ -29,7 +29,8 @@ class StartPlayingAction(Window.Action):
             frame_parameters_d = context.parameters.get("frame_parameters")
             if hardware_source:
                 frame_parameters = hardware_source.get_frame_parameters_from_dict(frame_parameters_d) if frame_parameters_d else None
-                hardware_source.start_playing(frame_parameters)
+                # frame parameters object must be passed by keyword, not positional.
+                hardware_source.start_playing(frame_parameters=frame_parameters)
         return Window.ActionResult(Window.ActionStatus.FINISHED)
 
     def get_action_summary(self, context: Window.ActionContext) -> str:

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -408,6 +408,7 @@ class ScanControlStateController:
                 self.__document_controller.perform_action_in_context("acquisition.stop_playing", action_context)
             else:
                 frame_parameters = self.__scan_hardware_source.get_frame_parameters(self.__scan_hardware_source.selected_profile_index)
+                frame_parameters.enabled_channel_indexes = self.__scan_hardware_source.get_enabled_channel_indexes()
                 action_context = self.__document_controller._get_action_context()
                 action_context.parameters["hardware_source_id"] = self.__scan_hardware_source.hardware_source_id
                 action_context.parameters["frame_parameters"] = frame_parameters.as_dict()

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -407,6 +407,8 @@ class ScanControlStateController:
                 action_context.parameters["hardware_source_id"] = self.__scan_hardware_source.hardware_source_id
                 self.__document_controller.perform_action_in_context("acquisition.stop_playing", action_context)
             else:
+                # the 'enabled channel indexes' implementation is incomplete, so, for now, explicitly add them to the
+                # frame parameters so that they can be recorded when logging the start playing action.
                 frame_parameters = self.__scan_hardware_source.get_frame_parameters(self.__scan_hardware_source.selected_profile_index)
                 frame_parameters.enabled_channel_indexes = self.__scan_hardware_source.get_enabled_channel_indexes()
                 action_context = self.__document_controller._get_action_context()


### PR DESCRIPTION
Fixes #234

The issue was that frame parameters for new start playing action
were not being applied because they needed to be passed by keyword
instead of positional. This caused issues after things like tuning.
