### PR TITLE
Fix another start playing action related issue when starting without frame parameters. Test.

### DIFF
--- a/nion/instrumentation/camera_base.py
+++ b/nion/instrumentation/camera_base.py
@@ -1562,9 +1562,9 @@ class CameraHardwareSource2(HardwareSource.ConcreteHardwareSource, CameraHardwar
                 self.log_messages_event.fire(messages, data_elements)
 
     def start_playing(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-        # note: sum_project has been mishandled in the past. it is not valid for view modes. clear it here.
-        if "frame_parameters" in kwargs:
-            camera_frame_parameters = typing.cast(CameraFrameParameters, kwargs["frame_parameters"])
+        camera_frame_parameters = typing.cast(CameraFrameParameters | None, kwargs.get("frame_parameters", None))
+        if camera_frame_parameters:
+            # note: sum_project has been mishandled in the past. it is not valid for view modes. clear it here.
             camera_frame_parameters.processing = None
             self.set_current_frame_parameters(camera_frame_parameters)
         elif len(args) == 1 and isinstance(args[0], dict):
@@ -2182,9 +2182,9 @@ class CameraHardwareSource3(HardwareSource.ConcreteHardwareSource, CameraHardwar
                 self.log_messages_event.fire(messages, data_elements)
 
     def start_playing(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-        # note: sum_project has been mishandled in the past. it is not valid for view modes. clear it here.
-        if "frame_parameters" in kwargs:
-            camera_frame_parameters = typing.cast(CameraFrameParameters, kwargs["frame_parameters"])
+        camera_frame_parameters = typing.cast(CameraFrameParameters | None, kwargs.get("frame_parameters", None))
+        if camera_frame_parameters:
+            # note: sum_project has been mishandled in the past. it is not valid for view modes. clear it here.
             camera_frame_parameters.processing = None
             self.set_current_frame_parameters(camera_frame_parameters)
         elif len(args) == 1 and isinstance(args[0], dict):

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -1304,11 +1304,12 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
         return self.__device
 
     def start_playing(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-        if "frame_parameters" in kwargs:
-            if hasattr(kwargs["frame_parameters"], "as_dict"):
-                frame_parameters = self.__settings.get_frame_parameters_from_dict(typing.cast(ParametersBase, kwargs["frame_parameters"]).as_dict())
+        frame_parameters = kwargs.get("frame_parameters", None)
+        if frame_parameters:
+            if hasattr(frame_parameters, "as_dict"):
+                frame_parameters = self.__settings.get_frame_parameters_from_dict(typing.cast(ParametersBase, frame_parameters).as_dict())
             else:
-                frame_parameters = self.__settings.get_frame_parameters_from_dict(typing.cast(typing.Dict[str, typing.Any], kwargs["frame_parameters"]))
+                frame_parameters = self.__settings.get_frame_parameters_from_dict(typing.cast(typing.Dict[str, typing.Any], frame_parameters))
             self.set_current_frame_parameters(frame_parameters)
         elif len(args) == 1 and isinstance(args[0], dict):
             # positional argument handling is only for backward compatibility and could be removed.

--- a/nion/instrumentation/test/CameraControl_test.py
+++ b/nion/instrumentation/test/CameraControl_test.py
@@ -1543,6 +1543,42 @@ class TestCameraControlClass(unittest.TestCase):
             finally:
                 display_panel_manager.unregister_display_panel_controller_factory("camera-live-" + hardware_source.hardware_source_id)
 
+    def test_camera_action_with_frame_parameters(self) -> None:
+        with self._test_context() as test_context:
+            document_controller = test_context.document_controller
+            document_model = test_context.document_model
+            hardware_source = test_context.camera_hardware_source
+            frame_parameters = hardware_source.get_frame_parameters(0)
+            frame_parameters.exposure_ms = 14
+            action_context = document_controller._get_action_context()
+            action_context.parameters["hardware_source_id"] = hardware_source.hardware_source_id
+            action_context.parameters["frame_parameters"] = frame_parameters.as_dict()
+            document_controller.perform_action_in_context("acquisition.start_playing", action_context)
+            start = time.time()
+            while not hardware_source.is_playing:
+                time.sleep(0.01)  # 10 msec
+                assert time.time() - start < 3.0
+            hardware_source.stop_playing(sync_timeout=3.0)
+            document_controller.periodic()
+            self.assertEqual(14/1000, document_model.data_items[0].metadata["hardware_source"]["exposure"])
+
+    def test_camera_action_with_no_frame_parameters(self) -> None:
+        # essentially just testing that acquisition works.
+        with self._test_context() as test_context:
+            document_controller = test_context.document_controller
+            document_model = test_context.document_model
+            hardware_source = test_context.camera_hardware_source
+            action_context = document_controller._get_action_context()
+            action_context.parameters["hardware_source_id"] = hardware_source.hardware_source_id
+            document_controller.perform_action_in_context("acquisition.start_playing", action_context)
+            start = time.time()
+            while not hardware_source.is_playing:
+                time.sleep(0.01)  # 10 msec
+                assert time.time() - start < 3.0
+            hardware_source.stop_playing(sync_timeout=3.0)
+            document_controller.periodic()
+            self.assertEqual(1, len(document_model.data_items))
+
     def planned_test_custom_view_followed_by_ui_view_uses_ui_frame_parameters(self):
         pass
 

--- a/nion/instrumentation/test/ScanControl_test.py
+++ b/nion/instrumentation/test/ScanControl_test.py
@@ -1996,6 +1996,22 @@ class TestScanControlClass(unittest.TestCase):
             document_controller.periodic()
             self.assertEqual((30, 40), document_model.data_items[0].data_shape)
 
+    def test_scan_action_with_no_frame_parameters(self) -> None:
+        with self._test_context() as test_context:
+            document_controller = test_context.document_controller
+            document_model = test_context.document_model
+            hardware_source = test_context.scan_hardware_source
+            action_context = document_controller._get_action_context()
+            action_context.parameters["hardware_source_id"] = hardware_source.hardware_source_id
+            document_controller.perform_action_in_context("acquisition.start_playing", action_context)
+            start = time.time()
+            while not hardware_source.is_playing:
+                time.sleep(0.01)  # 10 msec
+                assert time.time() - start < 3.0
+            hardware_source.stop_playing(sync_timeout=3.0)
+            document_controller.periodic()
+            self.assertEqual((256, 256), document_model.data_items[0].data_shape)
+
     # center_nm, center_x_nm, and center_y_nm are all sensible for context and subscans
     # all requested and actual frame parameters are recorded
     # stem values are recorded


### PR DESCRIPTION
This was long standing issue in how start playing handled the frame parameters
keyword parameter: it didn't handle None passed for the keyword value.

This is going in quickly as a hot fix. If you see issues, please contact me.