### PR TITLE
Fix #243. Dragging subscan to display panel restores correct controller.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ UNRELEASED
 - Fix issue where summed acquisitions could spuriously time out.
 - Improve granularity of progress bar during acquisition procedures.
 - Fix issue where disabling drift correction would not actually disable it.
+- Fix issue where dropping subscan data item on display panel would restore non-subscan controller.
 
 23.3.0 (2025-04-23)
 -------------------

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -430,7 +430,6 @@ def update_detector_metadata(detector_metadata: typing.MutableMapping[str, typin
     detector_metadata["line_time_us"] = line_time_us
 
 
-
 @dataclasses.dataclass
 class ScanAcquisitionTaskParameters(HardwareSource.AcquisitionTaskParameters):
     scan_id: typing.Optional[uuid.UUID] = None
@@ -829,6 +828,15 @@ class ScanHardwareSource(HardwareSource.HardwareSource, typing.Protocol):
     def calculate_flyback_pixels(self, frame_parameters: ScanFrameParameters) -> int: ...
 
     def get_view_data_channel_specifiers(self) -> typing.Optional[typing.Sequence[HardwareSource.DataChannelSpecifier]]: ...
+
+    def get_frame_parameters_from_metadata(self, metadata: typing.Mapping[str, typing.Any]) -> ScanFrameParameters | None:
+        """Return camera frame parameters from high-level metadata.
+
+        High-level metadata means the metadata stored at the data item level.
+
+        Subclasses may override this method to provide a custom subclass of ScanFrameParameters.
+        """
+        ...
 
     record_index: int
     priority: int = 100
@@ -1473,6 +1481,14 @@ class ConcreteScanHardwareSource(HardwareSource.ConcreteHardwareSource, ScanHard
                 xdata_group.append(xdata)
             xdata_group_list.append(xdata_group)
         return xdata_group_list
+
+    def get_frame_parameters_from_metadata(self, metadata: typing.Mapping[str, typing.Any]) -> ScanFrameParameters | None:
+        scan_d = metadata.get("scan")
+        if scan_d is not None:
+            scan_device_parameters_d = scan_d.get("scan_device_parameters")
+            if scan_device_parameters_d is not None:
+                return self.__settings.get_frame_parameters_from_dict(scan_device_parameters_d)
+        return None
 
     @property
     def subscan_state(self) -> STEMController.SubscanState:

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -2068,6 +2068,9 @@ def register_scan_panel(hardware_source: HardwareSource.HardwareSource) -> None:
                 return None
 
             def match(self, document_model: DocumentModel.DocumentModel, data_item: DataItem.DataItem) -> typing.Optional[Persistence.PersistentDictType]:
+                # determine whether the given data item represents a live view item that could be controlled by this display
+                # panel controller. if so, return a dictionary that can be used to restore the display panel controller.
+                # checks for the scan device channel and whether it is a subscan or drift channel.
                 assert isinstance(hardware_source, scan_base.ScanHardwareSource)
                 for channel_index in range(hardware_source.channel_count):
                     channel_id_ = hardware_source.get_channel_id(channel_index) or str()

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -2073,6 +2073,9 @@ def register_scan_panel(hardware_source: HardwareSource.HardwareSource) -> None:
                     channel_id_ = hardware_source.get_channel_id(channel_index) or str()
                     for channel_id in (channel_id_, channel_id_ + "_subscan", "drift"):
                         if HardwareSource.matches_hardware_source(hardware_source.hardware_source_id, channel_id, document_model, data_item):
+                            if frame_parameters := hardware_source.get_frame_parameters_from_metadata(data_item.metadata):
+                                if frame_parameters.subscan_pixel_size:
+                                    channel_id = channel_id_ + "_subscan"
                             return {"controller_type": ScanDisplayPanelController.type, "hardware_source_id": hardware_source.hardware_source_id, "channel_id": channel_id}
                 return None
 


### PR DESCRIPTION
I'd like to merge this in the next few days. Please review and comment. This change is lightly documented and does not have an associated integration test.