### PR TITLE
Ensure scan context is initialized at startup. Fixes #465, #471.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ UNRELEASED
 - Improve granularity of progress bar during acquisition procedures.
 - Fix issue where disabling drift correction would not actually disable it.
 - Fix issue where dropping subscan data item on display panel would restore non-subscan controller.
+- Fix regression where scan context not initialized properly.
 
 23.3.0 (2025-04-23)
 -------------------


### PR DESCRIPTION
My recent changes that eliminated the scan context state management (as much as possible) forgot to handle the case of initializing the scan context to match the initial scan parameters read from hardware. This fixes that.

I'd like to merge this within a few HOURS - so if you want to review, please contact me via chat to let me know to hold off on the merge.

Review strategy is to test against nion-software/nion-instrumentation#465 and nion-software/nion-instrumentation#471.