### PR TITLE
Add acquisition time/space usage estimate to acquisition panel

### DIFF
--- a/nionswift_plugin/nion_instrumentation_ui/AcquisitionPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/AcquisitionPanel.py
@@ -2080,7 +2080,7 @@ class BytesToStringConverter(Converter.ConverterLike[float, str]):
             tbytes = float(kbytes ** 4)  # 1,099,511,627,776
 
             if bytes < kbytes:
-                return '{0} {1}'.format(bytes, 'Bytes' if 0 == bytes > 1 else 'Byte')
+                return '{0} {1}'.format(bytes, 'Bytes' if bytes != 1 else 'Byte')
             elif kbytes <= bytes < mbytes:
                 return '{0:.2f} KB'.format(bytes / kbytes)
             elif mbytes <= bytes < gbytes:


### PR DESCRIPTION
- **Add new event to camera/scan hardware source for extended frame parameters, used for time/space usage.**
- **Add time and space usage estimates to acquisition panel.**

Please review the comments, code, and functionality. No timeline on merge, but would like to get reviews and testing when possible.

Testing acquisition panel time/space usage
- Time/space usage updates when any input parameter changes
- Repeat mode: None (just the device time/space usage)
- Repeat mode: 1D/2D (device usage * count, but with 200ms overhead for each device acquisition to change control parameter)
- 1D/2D does not handle control being exposure itself
- 1D/2D count(s) may change if control changes
- Repeat mode: Multiple (device usage * count for each row)
- Repeat mode: Sequence (device usage * count)
- Device: scan (time/shape/subscan/linescan in scan control panel)
- Device: camera (camera readout type, binning, readout area, dectris only, exposure in acquisition panel)
- Device: sync (everything in scan/camera + scan shape in acquisition panel)
- does not handle drift
- control overhead is fixed at 200ms, needs tuning
