### PR TITLE
Split out MetadataDisplayComponent 

### DIFF
--- a/nion/instrumentation/HardwareSource.py
+++ b/nion/instrumentation/HardwareSource.py
@@ -2009,10 +2009,12 @@ class MetadataDisplayComponent:
             if voltage % 1000 == 0:
                 voltage = voltage // 1000
                 units = "kV"
+            d["ht"] = f"{voltage} {units}"
             info_items.append(f"{voltage} {units}")
 
         hardware_source_name = Metadata.get_metadata_value(metadata, "stem.hardware_source.name")
         if hardware_source_name:
+            d["hardware"] = str(hardware_source_name)
             info_items.append(str(hardware_source_name))
 
         if info_items:


### PR DESCRIPTION
to facilitate specific elements being toggleable  within scale bar. info_items has been left in so that the merge doesn't break previous functionality within nionswift but the goal is to remove this