### PR TITLE
Stop shift/tilt state getting stuck when key up event is missed

### DIFF
--- a/nionswift_plugin/nion_instrumentation_ui/CameraControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/CameraControlPanel.py
@@ -672,7 +672,6 @@ class CameraControlWidget(Widgets.CompositeWidgetBase):
         self.__key_released_event_listener = DisplayPanel.DisplayPanelManager().key_released_event.listen(self.image_panel_key_released)
         self.__image_display_mouse_pressed_event_listener = DisplayPanel.DisplayPanelManager().image_display_mouse_pressed_event.listen(self.image_panel_mouse_pressed)
         self.__image_display_mouse_released_event_listener = DisplayPanel.DisplayPanelManager().image_display_mouse_released_event.listen(self.image_panel_mouse_released)
-        self.__focus_changed_event_listener = DisplayPanel.DisplayPanelManager().focus_changed_event.listen(self.image_panel_focus_changed)
         self.__mouse_pressed = False
 
         help_widget = None
@@ -1005,10 +1004,6 @@ class CameraControlWidget(Widgets.CompositeWidgetBase):
         return False
 
     def image_panel_key_released(self, display_panel: DisplayPanel.DisplayPanel, key: UserInterface.Key) -> bool:
-        self.__shift_click_state = None
-        return False
-
-    def image_panel_focus_changed(self, display_panel: DisplayPanel.DisplayPanel, focussed: bool) -> bool:
         self.__shift_click_state = None
         return False
 

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -1136,7 +1136,6 @@ class ScanControlWidget(Widgets.CompositeWidgetBase):
         self.__key_released_event_listener = DisplayPanel.DisplayPanelManager().key_released_event.listen(self.image_panel_key_released)
         self.__image_display_mouse_pressed_event_listener = DisplayPanel.DisplayPanelManager().image_display_mouse_pressed_event.listen(self.image_panel_mouse_pressed)
         self.__image_display_mouse_released_event_listener = DisplayPanel.DisplayPanelManager().image_display_mouse_released_event.listen(self.image_panel_mouse_released)
-        self.__focus_changed_event_listener = DisplayPanel.DisplayPanelManager().focus_changed_event.listen(self.image_panel_focus_changed)
         self.__mouse_pressed = False
 
         def handle_record_data_item(data_item: DataItem.DataItem) -> None:
@@ -1695,10 +1694,6 @@ class ScanControlWidget(Widgets.CompositeWidgetBase):
         return False
 
     def image_panel_key_released(self, display_panel: DisplayPanel.DisplayPanel, key: UserInterface.Key) -> bool:
-        self.__shift_click_state = None
-        return False
-
-    def image_panel_focus_changed(self, display_panel: DisplayPanel.DisplayPanel, focussed: bool) -> bool:
         self.__shift_click_state = None
         return False
 


### PR DESCRIPTION
Fix for https://github.com/nion-software/nion-instrumentation/issues/486

~~This uses the focus_changed_event added in https://github.com/nion-software/nionswift/pull/1574 to reset `shift_click_state` when the focus is lost by a display panel.~~

It consumes the state on the mouse click so that it is not left in that state if the key up event is missed for any reason.