### PR TITLE
Raise descriptive exception when scan likely not sync'd with camera. Add tests.

### DIFF
--- a/nion/instrumentation/Acquisition.py
+++ b/nion/instrumentation/Acquisition.py
@@ -3044,6 +3044,7 @@ def acquire(data_stream: DataStream, *, error_handler: typing.Optional[typing.Ca
             error_handler(e)
         else:
             import traceback
+            traceback.print_stack()
             traceback.print_exc()
 
 

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -2572,9 +2572,9 @@ class SynchronizedDataStream(Acquisition.ContainerDataStream):
     def _advance_stream(self) -> None:
         if time.perf_counter() - self.__scan_packet_time > max(self.__line_time * 4, SYNCHRONIZED_SCAN_TIMEOUT):
             if any(c >= 1 for c in self.__scan_packet_counts.values()):
-                raise RuntimeError(_("Scan data is arriving intermittently. Check the sync cables."))
+                raise RuntimeError(_("Scan data is arriving intermittently. Check the synchronization configuration (cables, routing, signal quality)."))
             else:
-                raise RuntimeError(_("Scan data is not arriving. Check the sync cables."))
+                raise RuntimeError(_("Scan data is not arriving. Check the synchronization configuration (cables, routing)."))
         super()._advance_stream()
 
     def _finish_stream(self) -> None:

--- a/nion/instrumentation/test/AcquisitionTestContext.py
+++ b/nion/instrumentation/test/AcquisitionTestContext.py
@@ -100,8 +100,8 @@ class AcquisitionTestContext(TestContext.MemoryProfileContext):
         self.__exit_stack.append(ex)
 
 
-def test_context(configuration: typing.Optional[AcquisitionTestContextConfigurationLike] = None, *, is_eels: bool = False, camera_exposure: float = 0.025, is_both_cameras: bool = False, is_app: bool = False) -> AcquisitionTestContext:
-    configuration_ = configuration or AcquisitionTestContextConfiguration.AcquisitionTestContextConfiguration()
+def test_context(configuration: typing.Optional[AcquisitionTestContextConfigurationLike] = None, *, is_eels: bool = False, camera_exposure: float = 0.025, is_both_cameras: bool = False, is_app: bool = False, advance_pixel_filter: typing.Callable[[int], bool] | None = None) -> AcquisitionTestContext:
+    configuration_ = configuration or AcquisitionTestContextConfiguration.AcquisitionTestContextConfiguration(advance_pixel_filter=advance_pixel_filter)
     return AcquisitionTestContext(configuration_, is_eels=is_eels, camera_exposure=camera_exposure, is_both_cameras=is_both_cameras, is_app=is_app)
 
 


### PR DESCRIPTION
Fixes nion-software/nion-instrumentation#454.

Please review this change. It watches for scan and camera packets and raises a descriptive exception if scan packets are not received in a timely manner, often indicating a synchronous issue in hardware.

This needs to be reviewed on real hardware for the positive case (actual sync cable missing, or sync signal unreliable); and the negative case (should not trigger exceptions when acquisition is working). We will need to test across a wide variety of scan widths, camera exposures, and acquisition options.

I included tests for the positive case; but I don't see any way to test for the negative (acquisition succeeds) case.