### PR TITLE
Add TryValue dataclass

### DIFF
--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -293,13 +293,14 @@ class ScanSpecifier:
             self.drift_interval_scans = drift_scans
             self.drift_correction_enabled = drift_correction_enabled
 
-class TryValue(typing.Protocol):
+T = typing.TypeVar('T', covariant=True)
+class TryValue(typing.Protocol, typing.Generic[T]):
     """ A value and an exception.
 
     The value is valid only if exception is None.
     """
     @property
-    def value(self) -> typing.Any: ...
+    def value(self) -> T | None: ...
 
     @property
     def exception(self) -> Exception | None: ...


### PR DESCRIPTION
Adding in a rich dataclass wrapper around control stream type including additional information such as current error status. Added get_control_try_value_stream to retrieve this extended return object.