### PR TITLE
Fix issue where click-to-shift on scan would ignore scan rotation. Add test.

### DIFF
--- a/nion/instrumentation/test/AcquisitionTestContextConfiguration.py
+++ b/nion/instrumentation/test/AcquisitionTestContextConfiguration.py
@@ -165,9 +165,15 @@ class ValueManager(InstrumentDevice.ValueManagerLike):
         return self.set_value(name, value)
 
     def get_value_2d(self, name: str, default_value: typing.Optional[Geometry.FloatPoint] = None, *, axis: typing.Optional[stem_controller.AxisType] = None) -> Geometry.FloatPoint:
-        return Geometry.FloatPoint()
+        axis = axis or ("x", "y")
+        y = self.get_value(name + axis[1]) or 0.0
+        x = self.get_value(name + axis[0]) or 0.0
+        return Geometry.FloatPoint(y, x)
 
     def set_value_2d(self, name: str, value: Geometry.FloatPoint, *, axis: typing.Optional[stem_controller.AxisType] = None) -> bool:
+        axis = axis or ("x", "y")
+        self.set_value(name + axis[1], value.y)
+        self.set_value(name + axis[0], value.x)
         return True
 
     def inform_control_2d(self, name: str, value: Geometry.FloatPoint, *, axis: stem_controller.AxisType) -> bool:

--- a/nion/instrumentation/test/ScanControl_test.py
+++ b/nion/instrumentation/test/ScanControl_test.py
@@ -1,6 +1,8 @@
 import contextlib
 import copy
 import json
+import logging
+import math
 import os
 import pathlib
 import random
@@ -46,6 +48,11 @@ class TestScanControlClass(unittest.TestCase):
     def tearDown(self) -> None:
         self._test_setup = typing.cast(typing.Any, None)
         AcquisitionTestContext.end_leaks(self)
+
+    def assertAlmostEqualPoint(self, p1, p2, e=0.00001):
+        if not(Geometry.distance(p1, p2) < e):
+            logging.info("%s != %s", p1, p2)
+        self.assertTrue(Geometry.distance(p1, p2) < e)
 
     def _acquire_one(self, document_controller, hardware_source):
         hardware_source.start_playing(sync_timeout=3.0)
@@ -2036,6 +2043,32 @@ class TestScanControlClass(unittest.TestCase):
                 scan_hardware_source.stop_playing(sync_timeout=3.0)
                 scan_hardware_source.set_channel_enabled(0, True)
                 scan_hardware_source.set_channel_enabled(1, False)
+
+    def test_shift_click_with_rotation(self):
+        with self._test_context() as test_context:
+            document_controller = test_context.document_controller
+            scan_hardware_source = test_context.scan_hardware_source
+            stem_controller_ = test_context.instrument
+            scan_frame_parameters = scan_hardware_source.get_current_frame_parameters()
+            scan_frame_parameters.pixel_size = Geometry.IntSize(100, 100)
+            scan_hardware_source.set_current_frame_parameters(scan_frame_parameters)
+            self._acquire_one(document_controller, scan_hardware_source)
+            self.assertAlmostEqualPoint(Geometry.FloatPoint(), stem_controller_.GetVal2D("stage_position_m"), e=1e-9)
+            logger = logging.getLogger("shift-click-test")
+            logger.addHandler(logging.NullHandler())
+            logger.propagate = False
+            scan_hardware_source.shift_click(Geometry.FloatPoint(53, 54), (100, 100), logger)
+            self.assertAlmostEqualPoint(Geometry.FloatPoint(y=-3e-9, x=-4e-9), stem_controller_.GetVal2D("stage_position_m"), e=1e-9)
+            scan_hardware_source.shift_click(Geometry.FloatPoint(47, 46), (100, 100), logger)
+            self.assertAlmostEqualPoint(Geometry.FloatPoint(), stem_controller_.GetVal2D("stage_position_m"), e=1e-9)
+            # now test rotated
+            scan_frame_parameters.rotation_rad = math.radians(45)
+            scan_hardware_source.set_current_frame_parameters(scan_frame_parameters)
+            self._acquire_one(document_controller, scan_hardware_source)
+            scan_hardware_source.shift_click(Geometry.FloatPoint(60, 50), (100, 100), logger)
+            self.assertAlmostEqualPoint(Geometry.FloatPoint(y=-math.sqrt(2)/2*1e-8, x=math.sqrt(2)/2*1e-8), stem_controller_.GetVal2D("stage_position_m"), e=1e-9)
+            scan_hardware_source.shift_click(Geometry.FloatPoint(40, 50), (100, 100), logger)
+            self.assertAlmostEqualPoint(Geometry.FloatPoint(), stem_controller_.GetVal2D("stage_position_m"), e=1e-9)
 
     # center_nm, center_x_nm, and center_y_nm are all sensible for context and subscans
     # all requested and actual frame parameters are recorded

--- a/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/ScanControlPanel.py
@@ -85,7 +85,6 @@ class ScanControlStateController:
         (event) probe_state_changed_event(probe_state, probe_position): "parked", "scanning"
         (event) channel_state_changed_event(channel_index, channel_id, channel_name, enabled)
         (read-only property) selected_profile_index: return current profile index
-        (read-only property) use_hardware_simulator: return True to use hardware simulator
         (read-only property) probe_state
         (read/write property) probe_position may be None
         (read-only property) channel_count


### PR DESCRIPTION
Fixes nion-software/nion-instrumentation#582