### PR TITLE
Ensure drift tracking between frames work in acquisition panel.

### DIFF
--- a/nionswift_plugin/nion_instrumentation_ui/AcquisitionPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/AcquisitionPanel.py
@@ -1079,8 +1079,12 @@ class ScanSpecifierValueStream(Stream.ValueStream[STEMController.ScanSpecifier])
             scan_width = self.__scan_width_model.value or 32
             assert scan_width is not None
 
+            # note: this is different from 'scan_hardware_source.drift_enabled' which is whether the drift graphic is on the context image
+            # this is a more direct indication of whether drift correction is enabled for scanning related items in the acquisition panel.
+            drift_enabled = self.__stem_controller.drift_settings.interval > 0
+
             scan_specifier = STEMController.ScanSpecifier()
-            scan_specifier.update(scan_hardware_source, exposure_time * 1000, scan_width, 1, False)
+            scan_specifier.update(scan_hardware_source, exposure_time * 1000, scan_width, 1, drift_enabled)
             self.send_value(scan_specifier)
 
 


### PR DESCRIPTION
Reviewers: please feel free to review and ask questions. It enables the missing feature of doing frame by frame drift tracking using HAADF images from acquisitions started from the acquisition panel. However, this may be difficult to understand exactly why these changes are required to enable drift correction in the acquisition panel context. This is a stop-gap until additional drift tracking cleanup.