### PR TITLE
Superclassing CameraFrameParameters off ParametersBase

### DIFF
--- a/nion/instrumentation/camera_base.py
+++ b/nion/instrumentation/camera_base.py
@@ -34,6 +34,7 @@ from nion.instrumentation import Acquisition
 from nion.instrumentation import AcquisitionPreferences
 from nion.instrumentation import HardwareSource
 from nion.instrumentation import stem_controller as STEMController
+from nion.instrumentation import scan_base
 from nion.swift.model import ImportExportManager
 from nion.swift.model import Utility
 from nion.swift.model import Graphics
@@ -599,7 +600,7 @@ class CameraDevice3(typing.Protocol):
         """
         return CameraFrameParameters(frame_parameters.as_dict())
 
-    def set_frame_parameters(self, frame_parameters: typing.Any) -> None:
+    def set_frame_parameters(self, frame_parameters: CameraFrameParameters) -> None:
         """Set the pending frame parameters (exposure_ms, binning, processing, integration_count).
 
         The parameters may be out of range or not precise; the device is free to use the closest value.
@@ -2533,77 +2534,61 @@ class CameraHardwareSource3(HardwareSource.ConcreteHardwareSource, CameraHardwar
         self.__camera_settings.open_configuration_interface(api_broker)
 
 
-class CameraFrameParameters:
+class CameraFrameParameters(scan_base.ParametersBase):
     """Camera frame parameters."""
-
-    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-        d: typing.Dict[str, typing.Any] = dict()
-        assert not args or isinstance(args[0], dict)
-        if args and isinstance(args[0], dict):
-            d.update(args[0])
-        d.update(kwargs)
-        self.exposure_ms: float = d.pop("exposure_ms", 125)
-        self.binning = d.pop("binning", 1)
-        self.processing = d.pop("processing", None)
-        self.integration_count = d.pop("integration_count", 1)
-        self.__is_validated = False
-        self.__active_masks = [Mask.from_dict(mask) if not isinstance(mask, Mask) else mask for mask in d.pop("active_masks", [])]
-        self.__extra = d
-
-    def __copy__(self) -> CameraFrameParameters:
-        return copy.deepcopy(self)
-
-    def __deepcopy__(self, memo: typing.Dict[typing.Any, typing.Any]) -> CameraFrameParameters:
-        deepcopy = self.__class__(copy.deepcopy(self.as_dict()))
-        memo[id(self)] = deepcopy
-        return deepcopy
-
-    def as_dict(self) -> typing.Dict[str, typing.Any]:
-        d = {
-            "exposure_ms": self.exposure_ms,
-            "exposure": self.exposure_ms / 1000,
-            "binning": self.binning,
-            "processing": self.processing,
-            "integration_count": self.integration_count,
-            "active_masks": [mask.as_dict() for mask in self.active_masks],
-        }
-        d.update(self.__extra)
-        return d
-
-    def __getitem__(self, item: str) -> typing.Any:
-        if hasattr(self, item):
-            return getattr(self, item)
-        else:
-            return self.__extra[item]
-
-    def __setitem__(self, key: str, value: typing.Any) -> None:
-        if hasattr(self, key):
-            setattr(self, key, value)
-        else:
-            self.__extra[key] = value
 
     @property
     def exposure(self) -> float:
-        return self.exposure_ms / 1000
+        exposure = self.get_parameter("exposure_ms", 125)
+        return typing.cast(float, exposure / 1000)
 
     @exposure.setter
     def exposure(self, value: float) -> None:
-        self.exposure_ms = value * 1000
+        self.set_parameter("exposure_ms", value * 1000)
 
     @property
-    def is_validated(self) -> bool:
-        return self.__is_validated
+    def exposure_ms(self) -> float:
+        exposure = self.get_parameter("exposure_ms", 125)
+        return typing.cast(float, exposure)
 
-    def _set_is_validated(self, is_validated: bool) -> None:
-        self.__is_validated = is_validated
+    @exposure_ms.setter
+    def exposure_ms(self, value: float) -> None:
+        self.set_parameter("exposure_ms", value)
+
+    @property
+    def binning(self) -> int:
+        binning = self.get_parameter("binning", 1)
+        return typing.cast(int, binning)
+
+    @binning.setter
+    def binning(self, value: int) -> None:
+        self.set_parameter("binning", value)
+
+    @property
+    def processing(self) -> str | None:
+        processing = self.get_parameter("processing", None)
+        return typing.cast(str|None, processing)
+
+    @processing.setter
+    def processing(self, value: str | None) -> None:
+        self.set_parameter("processing", value)
+
+    @property
+    def integration_count(self) -> int:
+        integration_count = self.get_parameter("integration_count", 1)
+        return typing.cast(int, integration_count)
+
+    @integration_count.setter
+    def integration_count(self, value: int) -> None:
+        self.set_parameter("integration_count", value)
 
     @property
     def active_masks(self) -> typing.Sequence[Mask]:
-        return self.__active_masks
+        return [Mask.from_dict(mask) for mask in self.get_parameter("active_masks", [])]
 
     @active_masks.setter
     def active_masks(self, value: typing.Union[typing.Sequence[Mask], typing.List[typing.Dict[str, typing.Any]]]) -> None:
-        self.__active_masks = [Mask.from_dict(mask) if not isinstance(mask, Mask) else mask for mask in value]
+        self.set_parameter("active_masks", [mask.as_dict() if isinstance(mask, Mask) else mask for mask in value])
 
 
 class CameraAcquisitionTaskParameters(HardwareSource.AcquisitionTaskParameters):

--- a/nion/instrumentation/test/CameraControl_test.py
+++ b/nion/instrumentation/test/CameraControl_test.py
@@ -1102,34 +1102,32 @@ class TestCameraControlClass(unittest.TestCase):
             hardware_source = test_context.camera_hardware_source
             frame_parameters = hardware_source.get_frame_parameters(0)
             # ensure it is initially dict-like
-            self.assertEqual(frame_parameters.exposure_ms, frame_parameters["exposure_ms"])
-            self.assertEqual(frame_parameters.binning, frame_parameters["binning"])
-            self.assertEqual(frame_parameters.processing, frame_parameters["processing"])
-            self.assertEqual(frame_parameters.integration_count, frame_parameters["integration_count"])
+            self.assertEqual(frame_parameters.exposure_ms, frame_parameters.exposure_ms)
+            self.assertEqual(frame_parameters.binning, frame_parameters.binning)
+            self.assertEqual(frame_parameters.processing, frame_parameters.processing)
+            self.assertEqual(frame_parameters.integration_count, frame_parameters.integration_count)
             # try setting values
-            frame_parameters["exposure_ms"] = 8.0
-            frame_parameters["binning"] = 8
-            frame_parameters["processing"] = "processing"
-            frame_parameters["integration_count"] = 8
+            frame_parameters.exposure_ms = 8.0
+            frame_parameters.binning = 8
+            frame_parameters.processing = "processing"
+            frame_parameters.integration_count = 8
             self.assertEqual(8.0, frame_parameters.exposure_ms)
             self.assertEqual(8, frame_parameters.binning)
             self.assertEqual("processing", frame_parameters.processing)
             self.assertEqual(8, frame_parameters.integration_count)
             # ensure masks are not None and can be set to masks or dict's but always return the object
             self.assertIsNotNone(frame_parameters.active_masks)
-            self.assertIsNotNone(frame_parameters["active_masks"])
             mask = camera_base.Mask()
             graphic = Graphics.RectangleGraphic()
             mask.add_layer(graphic, 1.0)
             graphic.close()
             frame_parameters.active_masks = [mask]
             self.assertEqual(frame_parameters.active_masks[0].to_dict(), mask.to_dict())
-            self.assertEqual(frame_parameters["active_masks"][0].to_dict(), mask.to_dict())  # mask is already a dict
             # test extra parameters
-            frame_parameters["extra"] = 8
-            self.assertEqual(8, frame_parameters["extra"])
+            frame_parameters.set_parameter("extra", 8)
+            self.assertEqual(8, frame_parameters.get_parameter("extra"))
             frame_parameters_copy = camera_base.CameraFrameParameters(frame_parameters.as_dict())
-            self.assertEqual(8, frame_parameters_copy["extra"])
+            self.assertEqual(8, frame_parameters_copy.get_parameter("extra"))
             # test dict is writeable to json
             json.dumps(frame_parameters.as_dict())
 


### PR DESCRIPTION
Fixes #327 
Superclassing CameraFrameParameters off ParametersBase.

Setting the superclass, and utilising that as the backend data store.  Moved attribute store to property access of backend data store to ensure single source of truth.