### PR TITLE
Update naming of ramp acquisition data items to '1D/2D Ramp'.

### DIFF
--- a/nion/instrumentation/Acquisition.py
+++ b/nion/instrumentation/Acquisition.py
@@ -3274,7 +3274,7 @@ class SeriesAcquisitionMethod(AcquisitionMethodLike):
             channel_names = device_data_stream.channel_names
             device_data_stream = SequenceDataStream(ActionDataStream(device_data_stream, action_delegate), self.__control_values.shape[0])
             device_data_stream.channel_names = channel_names
-            device_data_stream.title = _("Series")
+            device_data_stream.title = _("1D Ramp")
         return device_data_stream
 
 
@@ -3303,7 +3303,7 @@ class TableAcquisitionMethod(AcquisitionMethodLike):
                 self.__control_values.shape[0:2],
                 (Calibration.Calibration(), Calibration.Calibration()))
             device_data_stream.channel_names = channel_names
-            device_data_stream.title = _("Tableau")
+            device_data_stream.title = _("2D Ramp")
         return device_data_stream
 
 

--- a/nionswift_plugin/nion_instrumentation_ui/AcquisitionPanel.py
+++ b/nionswift_plugin/nion_instrumentation_ui/AcquisitionPanel.py
@@ -600,7 +600,7 @@ class SeriesAcquisitionMethodComponentHandler(AcquisitionMethodComponentHandler)
             if control_handler:
                 # get the control values range from the control handler.
                 return Acquisition.SeriesAcquisitionMethod(control_customization, control_handler.get_control_values())
-        return Acquisition.BasicAcquisitionMethod(_("Series"))
+        return Acquisition.BasicAcquisitionMethod(_("1D Ramp"))
 
 
 class TableauAcquisitionMethodComponentHandler(AcquisitionMethodComponentHandler):
@@ -762,7 +762,7 @@ class TableauAcquisitionMethodComponentHandler(AcquisitionMethodComponentHandler
                 x_control_values = x_control_handler.get_control_values()
                 control_values = numpy.stack(numpy.meshgrid(y_control_values, x_control_values, indexing='ij'), axis=-1)
                 return Acquisition.TableAcquisitionMethod(control_customization, axis_id, control_values)
-        return Acquisition.BasicAcquisitionMethod(_("Tableau"))
+        return Acquisition.BasicAcquisitionMethod(_("2D Ramp"))
 
 
 class MultiAcquireEntryHandler(Declarative.Handler):


### PR DESCRIPTION
Fixes #351.

Trivial change.