### PR TITLE
Acquire and release ronchigram camera

### DIFF
--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -337,7 +337,7 @@ class ReservedCamera:
 
     Can be used as a context manager for automatic release::
 
-        with instrument.try_reserve_ronchigram_camera("my-task") as reservation:
+        with instrument.try_reserve_ronchigram_camera() as reservation:
             if reservation.camera is None:
                 print(f"Failed: {reservation.failure_reason}")
                 return
@@ -345,7 +345,7 @@ class ReservedCamera:
 
     Or checked manually::
 
-        reservation = instrument.try_reserve_ronchigram_camera("my-task")
+        reservation = instrument.try_reserve_ronchigram_camera()
         if reservation.camera is None:
             return
         try:
@@ -419,9 +419,8 @@ class STEMController(Observable.Observable):
         self.scan_context_data_items_changed_event = Event.Event()
         self.scan_context_changed_event = Event.Event()
         self.__ronchigram_camera: typing.Optional[camera_base.CameraHardwareSource] = None
-        self.__ronchigram_camera_lock = threading.RLock()
         self._reserved_ronchigram_camera: weakref.ReferenceType[ReservedCamera] | None = None
-        self.__reserved_ronchigram_camera_finalize: weakref.finalize | None = None
+        self.__reserved_ronchigram_camera_finalize: weakref.finalize[typing.Any, typing.Any] | None = None
         self.__eels_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__slit_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__scan_controller: typing.Optional[scan_base.ScanHardwareSource] = None
@@ -463,44 +462,40 @@ class STEMController(Observable.Observable):
 
         Safe to use as a context manager::
 
-            with instrument.try_reserve_ronchigram_camera("my-task") as reservation:
+            with instrument.try_reserve_ronchigram_camera() as reservation:
                 if reservation.camera is None:
                     return
                 camera = reservation.camera
                 ...  # camera released automatically on exit
-
-        Args:
-            task_id (str): The task id of the current task.
         """
-        with self.__ronchigram_camera_lock:
-            if self._reserved_ronchigram_camera is not None:
-                existing_reservation = self._reserved_ronchigram_camera()
-                if existing_reservation is not None:
-                    return ReservedCamera(None,
-                                          failure_reason="Ronchigram camera is currently in use by another process",
-                                          status=ReservedCameraStatus.camera_already_reserved)
-                else:
-                    self._reserved_ronchigram_camera = None
-            ronchigram_camera = self.ronchigram_camera
-            if ronchigram_camera is not None:
-                reservation = ReservedCamera(ronchigram_camera,
-                                             release_fn=self.__release_ronchigram_camera,
-                                             status=ReservedCameraStatus.success)
-                self._reserved_ronchigram_camera = weakref.ref(reservation)
-                self.__reserved_ronchigram_camera_finalize = weakref.finalize(reservation, self.__release_ronchigram_camera)
-                return reservation
+        assert threading.current_thread() is threading.main_thread(), "try_reserve_ronchigram_camera must be called on the main thread."
+        if self._reserved_ronchigram_camera is not None:
+            existing_reservation = self._reserved_ronchigram_camera()
+            if existing_reservation is not None:
+                return ReservedCamera(None,
+                                      failure_reason="Ronchigram camera is currently in use by another process",
+                                      status=ReservedCameraStatus.camera_already_reserved)
+            else:
+                self._reserved_ronchigram_camera = None
+        ronchigram_camera = self.ronchigram_camera
+        if ronchigram_camera is not None:
+            reservation = ReservedCamera(ronchigram_camera,
+                                         release_fn=self.__release_ronchigram_camera,
+                                         status=ReservedCameraStatus.success)
+            self._reserved_ronchigram_camera = weakref.ref(reservation)
+            self.__reserved_ronchigram_camera_finalize = weakref.finalize(reservation, self.__release_ronchigram_camera)
+            return reservation
 
-            return ReservedCamera(None,
-                                  failure_reason="Ronchigram camera is not available",
-                                  status=ReservedCameraStatus.camera_not_found)
+        return ReservedCamera(None,
+                              failure_reason="Ronchigram camera is not available",
+                              status=ReservedCameraStatus.camera_not_found)
 
     def __release_ronchigram_camera(self) -> None:
         """Release a ronchigram camera previously reserved by try_reserve_ronchigram_camera."""
-        with self.__ronchigram_camera_lock:
-            self._reserved_ronchigram_camera = None
-            if self.__reserved_ronchigram_camera_finalize is not None:
-                self.__reserved_ronchigram_camera_finalize.detach()
-                self.__reserved_ronchigram_camera_finalize = None
+        self._reserved_ronchigram_camera = None
+        if self.__reserved_ronchigram_camera_finalize is not None:
+            self.__reserved_ronchigram_camera_finalize.detach()
+            self.__reserved_ronchigram_camera_finalize = None
 
     @property
     def eels_camera(self) -> typing.Optional[camera_base.CameraHardwareSource]:

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -362,7 +362,7 @@ class STEMController(Observable.Observable):
         self.scan_context_changed_event = Event.Event()
         self.__ronchigram_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__ronchigram_camera_lock = threading.RLock()
-        self._ronchigram_camera_acquired_count = 0 # exposed for tests
+        self._ronchigram_camera_reserved_count = 0 # exposed for tests
         self.__ronchigram_task_id: str | None = None
         self.__eels_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__slit_camera: typing.Optional[camera_base.CameraHardwareSource] = None
@@ -397,29 +397,29 @@ class STEMController(Observable.Observable):
         assert camera is None or camera.features.get("is_ronchigram_camera", False)
         self.__ronchigram_camera = typing.cast(typing.Optional["camera_base.CameraHardwareSource"], camera)
 
-    def try_acquire_ronchigram_camera(self, task_id: str) -> TryValue[camera_base.CameraHardwareSource]:
-        """Acquire the ronchigram camera if it is not already acquired by another task.
+    def try_reserve_ronchigram_camera(self, task_id: str) -> TryValue[camera_base.CameraHardwareSource]:
+        """Reserve the ronchigram camera if it is not already reserved by another task.
 
         The first successful call returns the current ronchigram camera and reserves it in a TryValue.
         Later calls return a TryValue with is_valid equal to False with a reason the camera cannot be reserved
         until the release_ronchigram_camera function has been called.
         """
         with self.__ronchigram_camera_lock:
-            if self._ronchigram_camera_acquired_count:
+            if self._ronchigram_camera_reserved_count:
                 return TryValue(None, Exception(f"Ronchigram camera is currently in use by task '{self.__ronchigram_task_id}'"))
             ronchigram_camera = self.ronchigram_camera
             if ronchigram_camera is not None:
-                self._ronchigram_camera_acquired_count += 1
+                self._ronchigram_camera_reserved_count += 1
                 self.__ronchigram_task_id = task_id
                 return TryValue(ronchigram_camera, copy_value=False)
 
             return TryValue(None, Exception("Ronchigram camera is not available"))
 
     def release_ronchigram_camera(self) -> None:
-        """Release a ronchigram camera previously reserved by try_acquire_ronchigram_camera."""
+        """Release a ronchigram camera previously reserved by try_reserve_ronchigram_camera."""
         with self.__ronchigram_camera_lock:
-            if self._ronchigram_camera_acquired_count > 0:
-                self._ronchigram_camera_acquired_count -= 1
+            if self._ronchigram_camera_reserved_count > 0:
+                self._ronchigram_camera_reserved_count -= 1
                 self.__ronchigram_task_id = None
 
     @property

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -331,6 +331,7 @@ class ReservedCameraStatus(enum.Enum):
     camera_not_found=1
     camera_already_reserved=2
 
+
 class ReservedCamera:
     """Represents a reserved camera.
 
@@ -368,9 +369,6 @@ class ReservedCamera:
         return self
 
     def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: types.TracebackType | None) -> None:
-        self.release()
-
-    def __del__(self) -> None:
         self.release()
 
     def release(self) -> None:
@@ -423,6 +421,7 @@ class STEMController(Observable.Observable):
         self.__ronchigram_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__ronchigram_camera_lock = threading.RLock()
         self._reserved_ronchigram_camera: weakref.ReferenceType[ReservedCamera] | None = None
+        self.__reserved_ronchigram_camera_finalize: weakref.finalize | None = None
         self.__eels_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__slit_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__scan_controller: typing.Optional[scan_base.ScanHardwareSource] = None
@@ -488,6 +487,7 @@ class STEMController(Observable.Observable):
                                              release_fn=self.__release_ronchigram_camera,
                                              status=ReservedCameraStatus.success)
                 self._reserved_ronchigram_camera = weakref.ref(reservation)
+                self.__reserved_ronchigram_camera_finalize = weakref.finalize(reservation, self.__release_ronchigram_camera)
                 return reservation
 
             return ReservedCamera(None,
@@ -498,6 +498,9 @@ class STEMController(Observable.Observable):
         """Release a ronchigram camera previously reserved by try_reserve_ronchigram_camera."""
         with self.__ronchigram_camera_lock:
             self._reserved_ronchigram_camera = None
+            if self.__reserved_ronchigram_camera_finalize is not None:
+                self.__reserved_ronchigram_camera_finalize.detach()
+                self.__reserved_ronchigram_camera_finalize = None
 
     @property
     def eels_camera(self) -> typing.Optional[camera_base.CameraHardwareSource]:

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -14,6 +14,7 @@ import threading
 import time
 import typing
 import uuid
+import weakref
 
 # third party libraries
 # None
@@ -323,6 +324,13 @@ class TryValue(typing.Generic[_TryValueType]):
         return self.exception is None
 
 
+class CameraReservedException(Exception):
+    """ Exception that signifies the selected camera is already reserved by another task. The task_id of the task that has reserved the camera is stored in the exception."""
+    def __init__(self, camera_name: str, task_id: str) -> None:
+        super().__init__(f"{camera_name} camera is currently in use by task '{task_id}'")
+        self.task_id = task_id
+
+
 class STEMController(Observable.Observable):
     """An interface to a STEM microscope.
 
@@ -364,6 +372,7 @@ class STEMController(Observable.Observable):
         self.__ronchigram_camera_lock = threading.RLock()
         self._ronchigram_camera_reserved_count = 0 # exposed for tests
         self.__ronchigram_task_id: str | None = None
+        self.__ronchigram_scope_token: weakref.ReferenceType[object] | None = None
         self.__eels_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__slit_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__scan_controller: typing.Optional[scan_base.ScanHardwareSource] = None
@@ -397,18 +406,37 @@ class STEMController(Observable.Observable):
         assert camera is None or camera.features.get("is_ronchigram_camera", False)
         self.__ronchigram_camera = typing.cast(typing.Optional["camera_base.CameraHardwareSource"], camera)
 
-    def try_reserve_ronchigram_camera(self, task_id: str) -> TryValue[camera_base.CameraHardwareSource]:
+    def __clear_ronchigram_camera_reservation(self) -> None:
+        """Clear the reservation of the ronchigram camera. This should be called when the camera is released or when the scope token is garbage collected."""
+        self._ronchigram_camera_reserved_count = 0
+        self.__ronchigram_task_id = None
+        self.__ronchigram_scope_token = None
+
+    def try_reserve_ronchigram_camera(self, task_id: str, scope_token: typing.Any) -> TryValue[camera_base.CameraHardwareSource]:
         """Reserve the ronchigram camera if it is not already reserved by another task.
 
         The first successful call returns the current ronchigram camera and reserves it in a TryValue.
         Later calls return a TryValue with is_valid equal to False with a reason the camera cannot be reserved
         until the release_ronchigram_camera function has been called.
+
+        Parameters:
+        task_id (str): The task id of the current task
+        scope_token (typing.Any): The scope token of the current task - if this object is garbage collected,
+            the reservation will be considered finished
         """
         with self.__ronchigram_camera_lock:
             if self._ronchigram_camera_reserved_count:
-                return TryValue(None, Exception(f"Ronchigram camera is currently in use by task '{self.__ronchigram_task_id}'"))
+                if self.__ronchigram_scope_token is None:
+                    return TryValue(None, CameraReservedException("Ronchigram", self.__ronchigram_task_id or ""))
+                if self.__ronchigram_scope_token() is not None:
+                    return TryValue(None, CameraReservedException("Ronchigram", self.__ronchigram_task_id or ""))
+                self.__clear_ronchigram_camera_reservation()
             ronchigram_camera = self.ronchigram_camera
             if ronchigram_camera is not None:
+                try:
+                    self.__ronchigram_scope_token = weakref.ref(scope_token)
+                except TypeError as e:
+                    raise TypeError("scope_token must support weak references (e.g., class instance)") from e
                 self._ronchigram_camera_reserved_count += 1
                 self.__ronchigram_task_id = task_id
                 return TryValue(ronchigram_camera, copy_value=False)
@@ -420,7 +448,8 @@ class STEMController(Observable.Observable):
         with self.__ronchigram_camera_lock:
             if self._ronchigram_camera_reserved_count > 0:
                 self._ronchigram_camera_reserved_count -= 1
-                self.__ronchigram_task_id = None
+                if self._ronchigram_camera_reserved_count == 0:
+                    self.__clear_ronchigram_camera_reservation()
 
     @property
     def eels_camera(self) -> typing.Optional[camera_base.CameraHardwareSource]:

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -325,6 +325,12 @@ class TryValue(typing.Generic[_TryValueType]):
         return self.exception is None
 
 
+class ReservedCameraStatus(enum.Enum):
+    invalid_reservation = -1
+    success=0
+    camera_not_found=1
+    camera_already_reserved=2
+
 class ReservedCamera:
     """Represents a reserved camera.
 
@@ -349,12 +355,13 @@ class ReservedCamera:
     ``camera`` is None if the reservation failed; ``failure_reason`` describes why.
     """
 
-    def __init__(self, camera: camera_base.CameraHardwareSource | None, task_id: str,
+    def __init__(self, camera: camera_base.CameraHardwareSource | None,
+                 status: ReservedCameraStatus,
                  release_fn: typing.Callable[[], None] | None = None,
                  failure_reason: str | None = None) -> None:
         self.camera = camera
-        self.task_id = task_id
         self.__release_fn = release_fn
+        self.status = status
         self.failure_reason = failure_reason
 
     def __enter__(self) -> ReservedCamera:
@@ -363,14 +370,17 @@ class ReservedCamera:
     def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: types.TracebackType | None) -> None:
         self.release()
 
+    def __del__(self) -> None:
+        self.release()
+
     def release(self) -> None:
         """Release this camera so other tasks can reserve it."""
         if self.__release_fn is not None:
             self.__release_fn()
             self.__release_fn = None
         self.camera = None
-        self.task_id = ""
-        self.failure_reason = "Invalid reservation"
+        self.status = ReservedCameraStatus.invalid_reservation
+        self.failure_reason = None
 
 
 class STEMController(Observable.Observable):
@@ -446,7 +456,7 @@ class STEMController(Observable.Observable):
         assert camera is None or camera.features.get("is_ronchigram_camera", False)
         self.__ronchigram_camera = typing.cast(typing.Optional["camera_base.CameraHardwareSource"], camera)
 
-    def try_reserve_ronchigram_camera(self, task_id: str) -> ReservedCamera:
+    def try_reserve_ronchigram_camera(self) -> ReservedCamera:
         """Reserve the ronchigram camera if it is not already reserved by another task.
 
         Always returns a ReservedCamera. Check ``reservation.camera``
@@ -467,19 +477,22 @@ class STEMController(Observable.Observable):
             if self._reserved_ronchigram_camera is not None:
                 existing_reservation = self._reserved_ronchigram_camera()
                 if existing_reservation is not None:
-                    return ReservedCamera(None, task_id,
-                                          failure_reason=f"Ronchigram camera is currently in use by task '{existing_reservation.task_id}'")
+                    return ReservedCamera(None,
+                                          failure_reason="Ronchigram camera is currently in use by another process",
+                                          status=ReservedCameraStatus.camera_already_reserved)
                 else:
                     self._reserved_ronchigram_camera = None
             ronchigram_camera = self.ronchigram_camera
             if ronchigram_camera is not None:
-                reservation = ReservedCamera(ronchigram_camera, task_id,
-                                             release_fn=self.__release_ronchigram_camera)
+                reservation = ReservedCamera(ronchigram_camera,
+                                             release_fn=self.__release_ronchigram_camera,
+                                             status=ReservedCameraStatus.success)
                 self._reserved_ronchigram_camera = weakref.ref(reservation)
                 return reservation
 
-            return ReservedCamera(None, task_id,
-                                  failure_reason="Ronchigram camera is not available")
+            return ReservedCamera(None,
+                                  failure_reason="Ronchigram camera is not available",
+                                  status=ReservedCameraStatus.camera_not_found)
 
     def __release_ronchigram_camera(self) -> None:
         """Release a ronchigram camera previously reserved by try_reserve_ronchigram_camera."""

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -454,7 +454,7 @@ class STEMController(Observable.Observable):
         assert camera is None or camera.features.get("is_ronchigram_camera", False)
         self.__ronchigram_camera = typing.cast(typing.Optional["camera_base.CameraHardwareSource"], camera)
 
-    def try_reserve_ronchigram_camera(self) -> ReservedCamera:
+    def _try_reserve_ronchigram_camera(self) -> ReservedCamera:
         """Reserve the ronchigram camera if it is not already reserved by another task.
 
         Always returns a ReservedCamera. Check ``reservation.camera``

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -361,6 +361,9 @@ class STEMController(Observable.Observable):
         self.scan_context_data_items_changed_event = Event.Event()
         self.scan_context_changed_event = Event.Event()
         self.__ronchigram_camera: typing.Optional[camera_base.CameraHardwareSource] = None
+        self.__ronchigram_camera_lock = threading.RLock()
+        self._ronchigram_camera_acquired_count = 0 # exposed for tests
+        self.__ronchigram_task_id: str | None = None
         self.__eels_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__slit_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__scan_controller: typing.Optional[scan_base.ScanHardwareSource] = None
@@ -393,6 +396,31 @@ class STEMController(Observable.Observable):
     def set_ronchigram_camera(self, camera: typing.Optional[HardwareSource.HardwareSource]) -> None:
         assert camera is None or camera.features.get("is_ronchigram_camera", False)
         self.__ronchigram_camera = typing.cast(typing.Optional["camera_base.CameraHardwareSource"], camera)
+
+    def try_acquire_ronchigram_camera(self, task_id: str) -> TryValue[camera_base.CameraHardwareSource]:
+        """Acquire the ronchigram camera if it is not already acquired by another task.
+
+        The first successful call returns the current ronchigram camera and reserves it in a TryValue.
+        Later calls return a TryValue with is_valid equal to False with a reason the camera cannot be reserved
+        until the release_ronchigram_camera function has been called.
+        """
+        with self.__ronchigram_camera_lock:
+            if self._ronchigram_camera_acquired_count:
+                return TryValue(None, Exception(f"Ronchigram camera is currently in use by task '{self.__ronchigram_task_id}'"))
+            ronchigram_camera = self.ronchigram_camera
+            if ronchigram_camera is not None:
+                self._ronchigram_camera_acquired_count += 1
+                self.__ronchigram_task_id = task_id
+                return TryValue(ronchigram_camera, copy_value=False)
+
+            return TryValue(None, Exception("Ronchigram camera is not available"))
+
+    def release_ronchigram_camera(self) -> None:
+        """Release a ronchigram camera previously reserved by try_acquire_ronchigram_camera."""
+        with self.__ronchigram_camera_lock:
+            if self._ronchigram_camera_acquired_count > 0:
+                self._ronchigram_camera_acquired_count -= 1
+                self.__ronchigram_task_id = None
 
     @property
     def eels_camera(self) -> typing.Optional[camera_base.CameraHardwareSource]:

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -326,7 +326,7 @@ class TryValue(typing.Generic[_TryValueType]):
 
 
 class ReservedCamera:
-    """Represents a reserved ronchigram camera.
+    """Represents a reserved camera.
 
     Can be used as a context manager for automatic release::
 
@@ -344,7 +344,7 @@ class ReservedCamera:
         try:
             ...
         finally:
-            reservation = None
+            reservation.release()
 
     ``camera`` is None if the reservation failed; ``failure_reason`` describes why.
     """
@@ -361,12 +361,16 @@ class ReservedCamera:
         return self
 
     def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: types.TracebackType | None) -> None:
+        self.release()
+
+    def release(self) -> None:
+        """Release this camera so other tasks can reserve it."""
         if self.__release_fn is not None:
             self.__release_fn()
+            self.__release_fn = None
         self.camera = None
         self.task_id = ""
         self.failure_reason = "Invalid reservation"
-        self.__release_fn = None
 
 
 class STEMController(Observable.Observable):

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -12,6 +12,7 @@ import logging
 import math
 import threading
 import time
+import types
 import typing
 import uuid
 import weakref
@@ -324,11 +325,48 @@ class TryValue(typing.Generic[_TryValueType]):
         return self.exception is None
 
 
-class CameraReservedException(Exception):
-    """ Exception that signifies the selected camera is already reserved by another task. The task_id of the task that has reserved the camera is stored in the exception."""
-    def __init__(self, camera_name: str, task_id: str) -> None:
-        super().__init__(f"{camera_name} camera is currently in use by task '{task_id}'")
+class ReservedCamera:
+    """Represents a reserved ronchigram camera.
+
+    Can be used as a context manager for automatic release::
+
+        with instrument.try_reserve_ronchigram_camera("my-task") as reservation:
+            if reservation.camera is None:
+                print(f"Failed: {reservation.failure_reason}")
+                return
+            # use reservation.camera here
+
+    Or checked manually::
+
+        reservation = instrument.try_reserve_ronchigram_camera("my-task")
+        if reservation.camera is None:
+            return
+        try:
+            ...
+        finally:
+            reservation = None
+
+    ``camera`` is None if the reservation failed; ``failure_reason`` describes why.
+    """
+
+    def __init__(self, camera: camera_base.CameraHardwareSource | None, task_id: str,
+                 release_fn: typing.Callable[[], None] | None = None,
+                 failure_reason: str | None = None) -> None:
+        self.camera = camera
         self.task_id = task_id
+        self.__release_fn = release_fn
+        self.failure_reason = failure_reason
+
+    def __enter__(self) -> ReservedCamera:
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: types.TracebackType | None) -> None:
+        if self.__release_fn is not None:
+            self.__release_fn()
+        self.camera = None
+        self.task_id = ""
+        self.failure_reason = "Invalid reservation"
+        self.__release_fn = None
 
 
 class STEMController(Observable.Observable):
@@ -370,9 +408,7 @@ class STEMController(Observable.Observable):
         self.scan_context_changed_event = Event.Event()
         self.__ronchigram_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__ronchigram_camera_lock = threading.RLock()
-        self._ronchigram_camera_reserved_count = 0 # exposed for tests
-        self.__ronchigram_task_id: str | None = None
-        self.__ronchigram_scope_token: weakref.ReferenceType[object] | None = None
+        self._reserved_ronchigram_camera: weakref.ReferenceType[ReservedCamera] | None = None
         self.__eels_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__slit_camera: typing.Optional[camera_base.CameraHardwareSource] = None
         self.__scan_controller: typing.Optional[scan_base.ScanHardwareSource] = None
@@ -406,50 +442,45 @@ class STEMController(Observable.Observable):
         assert camera is None or camera.features.get("is_ronchigram_camera", False)
         self.__ronchigram_camera = typing.cast(typing.Optional["camera_base.CameraHardwareSource"], camera)
 
-    def __clear_ronchigram_camera_reservation(self) -> None:
-        """Clear the reservation of the ronchigram camera. This should be called when the camera is released or when the scope token is garbage collected."""
-        self._ronchigram_camera_reserved_count = 0
-        self.__ronchigram_task_id = None
-        self.__ronchigram_scope_token = None
-
-    def try_reserve_ronchigram_camera(self, task_id: str, scope_token: typing.Any) -> TryValue[camera_base.CameraHardwareSource]:
+    def try_reserve_ronchigram_camera(self, task_id: str) -> ReservedCamera:
         """Reserve the ronchigram camera if it is not already reserved by another task.
 
-        The first successful call returns the current ronchigram camera and reserves it in a TryValue.
-        Later calls return a TryValue with is_valid equal to False with a reason the camera cannot be reserved
-        until the release_ronchigram_camera function has been called.
+        Always returns a ReservedCamera. Check ``reservation.camera``
+        to determine whether the reservation succeeded.
 
-        Parameters:
-        task_id (str): The task id of the current task
-        scope_token (typing.Any): The scope token of the current task - if this object is garbage collected,
-            the reservation will be considered finished
+        Safe to use as a context manager::
+
+            with instrument.try_reserve_ronchigram_camera("my-task") as reservation:
+                if reservation.camera is None:
+                    return
+                camera = reservation.camera
+                ...  # camera released automatically on exit
+
+        Args:
+            task_id (str): The task id of the current task.
         """
         with self.__ronchigram_camera_lock:
-            if self._ronchigram_camera_reserved_count:
-                if self.__ronchigram_scope_token is None:
-                    return TryValue(None, CameraReservedException("Ronchigram", self.__ronchigram_task_id or ""))
-                if self.__ronchigram_scope_token() is not None:
-                    return TryValue(None, CameraReservedException("Ronchigram", self.__ronchigram_task_id or ""))
-                self.__clear_ronchigram_camera_reservation()
+            if self._reserved_ronchigram_camera is not None:
+                existing_reservation = self._reserved_ronchigram_camera()
+                if existing_reservation is not None:
+                    return ReservedCamera(None, task_id,
+                                          failure_reason=f"Ronchigram camera is currently in use by task '{existing_reservation.task_id}'")
+                else:
+                    self._reserved_ronchigram_camera = None
             ronchigram_camera = self.ronchigram_camera
             if ronchigram_camera is not None:
-                try:
-                    self.__ronchigram_scope_token = weakref.ref(scope_token)
-                except TypeError as e:
-                    raise TypeError("scope_token must support weak references (e.g., class instance)") from e
-                self._ronchigram_camera_reserved_count += 1
-                self.__ronchigram_task_id = task_id
-                return TryValue(ronchigram_camera, copy_value=False)
+                reservation = ReservedCamera(ronchigram_camera, task_id,
+                                             release_fn=self.__release_ronchigram_camera)
+                self._reserved_ronchigram_camera = weakref.ref(reservation)
+                return reservation
 
-            return TryValue(None, Exception("Ronchigram camera is not available"))
+            return ReservedCamera(None, task_id,
+                                  failure_reason="Ronchigram camera is not available")
 
-    def release_ronchigram_camera(self) -> None:
+    def __release_ronchigram_camera(self) -> None:
         """Release a ronchigram camera previously reserved by try_reserve_ronchigram_camera."""
         with self.__ronchigram_camera_lock:
-            if self._ronchigram_camera_reserved_count > 0:
-                self._ronchigram_camera_reserved_count -= 1
-                if self._ronchigram_camera_reserved_count == 0:
-                    self.__clear_ronchigram_camera_reservation()
+            self._reserved_ronchigram_camera = None
 
     @property
     def eels_camera(self) -> typing.Optional[camera_base.CameraHardwareSource]:

--- a/nion/instrumentation/test/stem_controller_test.py
+++ b/nion/instrumentation/test/stem_controller_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import threading
 import typing
 import unittest
 
@@ -90,3 +92,27 @@ class TestSTEMControllerClass(unittest.TestCase):
             self.assertEqual(reservation2.status, ReservedCameraStatus.success)
 
             reservation2.release()
+
+    def test_cannot_reserve_in_thread(self):
+        with self._test_context() as test_context:
+            exception = None
+            def reserve_camera():
+                nonlocal exception
+                try:
+                    test_context.instrument.try_reserve_ronchigram_camera()
+                except Exception as e:
+                    exception = e
+
+            thread = threading.Thread(target=reserve_camera)
+            thread.start()
+            thread.join()
+            self.assertIsNotNone(exception)
+
+    def test_can_reserve_in_async(self):
+        with self._test_context() as test_context:
+            async def reserve_camera_async():
+                with test_context.instrument.try_reserve_ronchigram_camera() as reservation:
+                    return reservation.status
+
+            result = asyncio.run(reserve_camera_async())
+            self.assertEqual(result, ReservedCameraStatus.success)

--- a/nion/instrumentation/test/stem_controller_test.py
+++ b/nion/instrumentation/test/stem_controller_test.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import typing
+import unittest
+
+from nion.instrumentation.test import AcquisitionTestContext
+from nion.swift.test import TestContext
+
+class TestScanControlClass(unittest.TestCase):
+
+    def setUp(self):
+        AcquisitionTestContext.begin_leaks()
+        self._test_setup = TestContext.TestSetup()
+
+    def tearDown(self) -> None:
+        self._test_setup = typing.cast(typing.Any, None)
+        AcquisitionTestContext.end_leaks(self)
+
+    def _test_context(self) -> AcquisitionTestContext.AcquisitionTestContext:
+        # subclasses may override this to provide a different configuration
+        return AcquisitionTestContext.test_context()
+
+    def test_acquire_and_release_ronchigram_camera(self):
+        with self._test_context() as test_context:
+            result = test_context.instrument.try_acquire_ronchigram_camera("test")
+            self.assertTrue(result.is_valid)
+            self.assertEqual(1, test_context.instrument._ronchigram_camera_acquired_count)
+
+            test_context.instrument.release_ronchigram_camera()
+            self.assertEqual(0, test_context.instrument._ronchigram_camera_acquired_count)
+
+    def test_acquire_ronchigram_camera_twice(self):
+        with self._test_context() as test_context:
+            result = test_context.instrument.try_acquire_ronchigram_camera("test")
+            self.assertTrue(result.is_valid)
+            self.assertEqual(1, test_context.instrument._ronchigram_camera_acquired_count)
+
+            result2 = test_context.instrument.try_acquire_ronchigram_camera("test2")
+            self.assertFalse(result2.is_valid)
+            self.assertEqual(1, test_context.instrument._ronchigram_camera_acquired_count)

--- a/nion/instrumentation/test/stem_controller_test.py
+++ b/nion/instrumentation/test/stem_controller_test.py
@@ -1,16 +1,10 @@
 from __future__ import annotations
 
-import gc
 import typing
 import unittest
 
-from nion.instrumentation.stem_controller import CameraReservedException
 from nion.instrumentation.test import AcquisitionTestContext
 from nion.swift.test import TestContext
-
-
-class _ScopeToken:
-    pass
 
 
 class TestSTEMControllerClass(unittest.TestCase):
@@ -28,68 +22,56 @@ class TestSTEMControllerClass(unittest.TestCase):
 
     def test_reserve_and_release_ronchigram_camera(self):
         with self._test_context() as test_context:
-            scope_token = _ScopeToken()
-            result = test_context.instrument.try_reserve_ronchigram_camera("test", scope_token)
-            self.assertTrue(result.is_valid)
-            self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
+            reservation = test_context.instrument.try_reserve_ronchigram_camera("test")
+            self.assertIsNotNone(reservation)
+            self.assertIsNotNone(reservation.camera)
+            self.assertEqual("test", reservation.task_id)
+            self.assertIsNone(reservation.failure_reason)
+            self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
 
-            test_context.instrument.release_ronchigram_camera()
-            self.assertEqual(0, test_context.instrument._ronchigram_camera_reserved_count)
+            reservation = None
+            self.assertIsNone(test_context.instrument._reserved_ronchigram_camera())
+
+    def test_reserve_and_out_of_scope_release_ronchigram_camera(self):
+        with self._test_context() as test_context:
+            with test_context.instrument.try_reserve_ronchigram_camera("test") as reservation:
+                self.assertIsNotNone(reservation)
+                self.assertIsNotNone(reservation.camera)
+                self.assertEqual("test", reservation.task_id)
+                self.assertIsNone(reservation.failure_reason)
+                self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
+
+            self.assertIsNone(test_context.instrument._reserved_ronchigram_camera)
 
     def test_reserve_ronchigram_camera_twice(self):
         with self._test_context() as test_context:
-            scope_token = _ScopeToken()
-            result = test_context.instrument.try_reserve_ronchigram_camera("test", scope_token)
-            self.assertTrue(result.is_valid)
-            self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
+            reservation = test_context.instrument.try_reserve_ronchigram_camera("test")
+            self.assertIsNotNone(reservation)
+            self.assertIsNotNone(reservation.camera)
+            self.assertEqual("test", reservation.task_id)
+            self.assertIsNone(reservation.failure_reason)
+            self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
 
-            result2 = test_context.instrument.try_reserve_ronchigram_camera("test2", scope_token)
-            self.assertFalse(result2.is_valid)
-            self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
+            reservation2 = test_context.instrument.try_reserve_ronchigram_camera("test2")
+            self.assertIsNone(reservation2.camera)
+            self.assertIsNotNone(reservation2.failure_reason)
+            self.assertIn("test", reservation2.failure_reason)
 
-            test_context.instrument.release_ronchigram_camera()
+            reservation = None
+            reservation2 = None
 
-    def test_collected_scope_token_allows_new_reservation(self):
+    def test_leaving_scope_allows_new_reservation(self):
         with self._test_context() as test_context:
-            scope_token = _ScopeToken()
-            result = test_context.instrument.try_reserve_ronchigram_camera("test", scope_token)
-            self.assertTrue(result.is_valid)
-            self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
+            with test_context.instrument.try_reserve_ronchigram_camera("test") as reservation:
+                self.assertIsNotNone(reservation)
+                self.assertIsNotNone(reservation.camera)
+                self.assertEqual("test", reservation.task_id)
+                self.assertIsNone(reservation.failure_reason)
+                self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
 
-            test_context.instrument.release_ronchigram_camera()
-            self.assertEqual(0, test_context.instrument._ronchigram_camera_reserved_count)
+            reservation2 = test_context.instrument.try_reserve_ronchigram_camera("test2")
+            self.assertIsNotNone(reservation2)
+            self.assertIsNotNone(reservation2.camera)
+            self.assertIsNone(reservation2.failure_reason)
 
-            # Now allow scope_token to be garbage collected and try to reserve again
-            # This tests the scenario where the scope token is collected before the second
-            # reservation attempt, with _ronchigram_camera_reserved_count already at 0
-            scope_token = None
-            gc.collect()
-            scope_token2 = _ScopeToken()
-
-            result2 = test_context.instrument.try_reserve_ronchigram_camera("test2", scope_token2)
-            self.assertTrue(result2.is_valid)
-            self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
-
-            test_context.instrument.release_ronchigram_camera()
-
-    def test_release_without_reservation(self):
-        with self._test_context() as test_context:
-            # Verify that releasing without a prior reservation is a safe no-op
-            self.assertEqual(0, test_context.instrument._ronchigram_camera_reserved_count)
-            test_context.instrument.release_ronchigram_camera()
-            # Verify state is not corrupted
-            self.assertEqual(0, test_context.instrument._ronchigram_camera_reserved_count)
-
-    def test_reservation_failure_contains_correct_exception(self):
-        with self._test_context() as test_context:
-            scope_token = _ScopeToken()
-            result = test_context.instrument.try_reserve_ronchigram_camera("first_task", scope_token)
-            self.assertTrue(result.is_valid)
-
-            result2 = test_context.instrument.try_reserve_ronchigram_camera("second_task", scope_token)
-            self.assertFalse(result2.is_valid)
-            # Verify the exception is CameraReservedException with the correct task_id
-            self.assertIsInstance(result2.exception, CameraReservedException)
-            self.assertEqual("first_task", result2.exception.task_id)
-
-            test_context.instrument.release_ronchigram_camera()
+            reservation2 = None

--- a/nion/instrumentation/test/stem_controller_test.py
+++ b/nion/instrumentation/test/stem_controller_test.py
@@ -25,7 +25,7 @@ class TestSTEMControllerClass(unittest.TestCase):
 
     def test_reserve_and_release_ronchigram_camera(self):
         with self._test_context() as test_context:
-            reservation = test_context.instrument.try_reserve_ronchigram_camera()
+            reservation = test_context.instrument._try_reserve_ronchigram_camera()
             self.assertIsNotNone(reservation)
             self.assertIsNotNone(reservation.camera)
             self.assertIsNone(reservation.failure_reason)
@@ -37,7 +37,7 @@ class TestSTEMControllerClass(unittest.TestCase):
 
     def test_reserve_and_release_ronchigram_camera_via_context_manager(self):
         with self._test_context() as test_context:
-            with test_context.instrument.try_reserve_ronchigram_camera() as reservation:
+            with test_context.instrument._try_reserve_ronchigram_camera() as reservation:
                 self.assertIsNotNone(reservation)
                 self.assertIsNotNone(reservation.camera)
                 self.assertIsNone(reservation.failure_reason)
@@ -48,14 +48,14 @@ class TestSTEMControllerClass(unittest.TestCase):
 
     def test_reserve_ronchigram_camera_twice(self):
         with self._test_context() as test_context:
-            reservation = test_context.instrument.try_reserve_ronchigram_camera()
+            reservation = test_context.instrument._try_reserve_ronchigram_camera()
             self.assertIsNotNone(reservation)
             self.assertIsNotNone(reservation.camera)
             self.assertIsNone(reservation.failure_reason)
             self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
             self.assertEqual(reservation.status, ReservedCameraStatus.success)
 
-            reservation2 = test_context.instrument.try_reserve_ronchigram_camera()
+            reservation2 = test_context.instrument._try_reserve_ronchigram_camera()
             self.assertIsNone(reservation2.camera)
             self.assertIsNotNone(reservation2.failure_reason)
             self.assertEqual(reservation2.status, ReservedCameraStatus.camera_already_reserved)
@@ -65,14 +65,14 @@ class TestSTEMControllerClass(unittest.TestCase):
 
     def test_leaving_with_scope_allows_new_reservation(self):
         with self._test_context() as test_context:
-            with test_context.instrument.try_reserve_ronchigram_camera() as reservation:
+            with test_context.instrument._try_reserve_ronchigram_camera() as reservation:
                 self.assertIsNotNone(reservation)
                 self.assertIsNotNone(reservation.camera)
                 self.assertIsNone(reservation.failure_reason)
                 self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
                 self.assertEqual(reservation.status, ReservedCameraStatus.success)
 
-            reservation2 = test_context.instrument.try_reserve_ronchigram_camera()
+            reservation2 = test_context.instrument._try_reserve_ronchigram_camera()
             self.assertIsNotNone(reservation2)
             self.assertIsNotNone(reservation2.camera)
             self.assertIsNone(reservation2.failure_reason)
@@ -82,10 +82,10 @@ class TestSTEMControllerClass(unittest.TestCase):
 
     def test_unreleased_out_of_scope_reservation_allows_new_reservation(self):
         with self._test_context() as test_context:
-            reservation = test_context.instrument.try_reserve_ronchigram_camera()
+            reservation = test_context.instrument._try_reserve_ronchigram_camera()
             reservation = None
 
-            reservation2 = test_context.instrument.try_reserve_ronchigram_camera()
+            reservation2 = test_context.instrument._try_reserve_ronchigram_camera()
             self.assertIsNotNone(reservation2)
             self.assertIsNotNone(reservation2.camera)
             self.assertIsNone(reservation2.failure_reason)
@@ -99,7 +99,7 @@ class TestSTEMControllerClass(unittest.TestCase):
             def reserve_camera():
                 nonlocal exception
                 try:
-                    test_context.instrument.try_reserve_ronchigram_camera()
+                    test_context.instrument._try_reserve_ronchigram_camera()
                 except Exception as e:
                     exception = e
 
@@ -111,7 +111,7 @@ class TestSTEMControllerClass(unittest.TestCase):
     def test_can_reserve_in_async(self):
         with self._test_context() as test_context:
             async def reserve_camera_async():
-                with test_context.instrument.try_reserve_ronchigram_camera() as reservation:
+                with test_context.instrument._try_reserve_ronchigram_camera() as reservation:
                     return reservation.status
 
             result = asyncio.run(reserve_camera_async())

--- a/nion/instrumentation/test/stem_controller_test.py
+++ b/nion/instrumentation/test/stem_controller_test.py
@@ -29,10 +29,10 @@ class TestSTEMControllerClass(unittest.TestCase):
             self.assertIsNone(reservation.failure_reason)
             self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
 
-            reservation = None
-            self.assertIsNone(test_context.instrument._reserved_ronchigram_camera())
+            reservation.release()
+            self.assertIsNone(test_context.instrument._reserved_ronchigram_camera)
 
-    def test_reserve_and_out_of_scope_release_ronchigram_camera(self):
+    def test_reserve_and_release_ronchigram_camera_via_context_manager(self):
         with self._test_context() as test_context:
             with test_context.instrument.try_reserve_ronchigram_camera("test") as reservation:
                 self.assertIsNotNone(reservation)
@@ -57,10 +57,10 @@ class TestSTEMControllerClass(unittest.TestCase):
             self.assertIsNotNone(reservation2.failure_reason)
             self.assertIn("test", reservation2.failure_reason)
 
-            reservation = None
-            reservation2 = None
+            reservation.release()
+            reservation2.release()
 
-    def test_leaving_scope_allows_new_reservation(self):
+    def test_leaving_with_scope_allows_new_reservation(self):
         with self._test_context() as test_context:
             with test_context.instrument.try_reserve_ronchigram_camera("test") as reservation:
                 self.assertIsNotNone(reservation)
@@ -74,4 +74,16 @@ class TestSTEMControllerClass(unittest.TestCase):
             self.assertIsNotNone(reservation2.camera)
             self.assertIsNone(reservation2.failure_reason)
 
-            reservation2 = None
+            reservation2.release()
+
+    def test_unreleased_out_of_scope_reservation_allows_new_reservation(self):
+        with self._test_context() as test_context:
+            reservation = test_context.instrument.try_reserve_ronchigram_camera("test")
+            reservation = None
+
+            reservation2 = test_context.instrument.try_reserve_ronchigram_camera("test2")
+            self.assertIsNotNone(reservation2)
+            self.assertIsNotNone(reservation2.camera)
+            self.assertIsNone(reservation2.failure_reason)
+
+            reservation2.release()

--- a/nion/instrumentation/test/stem_controller_test.py
+++ b/nion/instrumentation/test/stem_controller_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing
 import unittest
 
+from nion.instrumentation.stem_controller import ReservedCameraStatus
 from nion.instrumentation.test import AcquisitionTestContext
 from nion.swift.test import TestContext
 
@@ -22,68 +23,70 @@ class TestSTEMControllerClass(unittest.TestCase):
 
     def test_reserve_and_release_ronchigram_camera(self):
         with self._test_context() as test_context:
-            reservation = test_context.instrument.try_reserve_ronchigram_camera("test")
+            reservation = test_context.instrument.try_reserve_ronchigram_camera()
             self.assertIsNotNone(reservation)
             self.assertIsNotNone(reservation.camera)
-            self.assertEqual("test", reservation.task_id)
             self.assertIsNone(reservation.failure_reason)
             self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
+            self.assertEqual(reservation.status, ReservedCameraStatus.success)
 
             reservation.release()
             self.assertIsNone(test_context.instrument._reserved_ronchigram_camera)
 
     def test_reserve_and_release_ronchigram_camera_via_context_manager(self):
         with self._test_context() as test_context:
-            with test_context.instrument.try_reserve_ronchigram_camera("test") as reservation:
+            with test_context.instrument.try_reserve_ronchigram_camera() as reservation:
                 self.assertIsNotNone(reservation)
                 self.assertIsNotNone(reservation.camera)
-                self.assertEqual("test", reservation.task_id)
                 self.assertIsNone(reservation.failure_reason)
                 self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
+                self.assertEqual(reservation.status, ReservedCameraStatus.success)
 
             self.assertIsNone(test_context.instrument._reserved_ronchigram_camera)
 
     def test_reserve_ronchigram_camera_twice(self):
         with self._test_context() as test_context:
-            reservation = test_context.instrument.try_reserve_ronchigram_camera("test")
+            reservation = test_context.instrument.try_reserve_ronchigram_camera()
             self.assertIsNotNone(reservation)
             self.assertIsNotNone(reservation.camera)
-            self.assertEqual("test", reservation.task_id)
             self.assertIsNone(reservation.failure_reason)
             self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
+            self.assertEqual(reservation.status, ReservedCameraStatus.success)
 
-            reservation2 = test_context.instrument.try_reserve_ronchigram_camera("test2")
+            reservation2 = test_context.instrument.try_reserve_ronchigram_camera()
             self.assertIsNone(reservation2.camera)
             self.assertIsNotNone(reservation2.failure_reason)
-            self.assertIn("test", reservation2.failure_reason)
+            self.assertEqual(reservation2.status, ReservedCameraStatus.camera_already_reserved)
 
             reservation.release()
             reservation2.release()
 
     def test_leaving_with_scope_allows_new_reservation(self):
         with self._test_context() as test_context:
-            with test_context.instrument.try_reserve_ronchigram_camera("test") as reservation:
+            with test_context.instrument.try_reserve_ronchigram_camera() as reservation:
                 self.assertIsNotNone(reservation)
                 self.assertIsNotNone(reservation.camera)
-                self.assertEqual("test", reservation.task_id)
                 self.assertIsNone(reservation.failure_reason)
                 self.assertIsNotNone(test_context.instrument._reserved_ronchigram_camera)
+                self.assertEqual(reservation.status, ReservedCameraStatus.success)
 
-            reservation2 = test_context.instrument.try_reserve_ronchigram_camera("test2")
+            reservation2 = test_context.instrument.try_reserve_ronchigram_camera()
             self.assertIsNotNone(reservation2)
             self.assertIsNotNone(reservation2.camera)
             self.assertIsNone(reservation2.failure_reason)
+            self.assertEqual(reservation2.status, ReservedCameraStatus.success)
 
             reservation2.release()
 
     def test_unreleased_out_of_scope_reservation_allows_new_reservation(self):
         with self._test_context() as test_context:
-            reservation = test_context.instrument.try_reserve_ronchigram_camera("test")
+            reservation = test_context.instrument.try_reserve_ronchigram_camera()
             reservation = None
 
-            reservation2 = test_context.instrument.try_reserve_ronchigram_camera("test2")
+            reservation2 = test_context.instrument.try_reserve_ronchigram_camera()
             self.assertIsNotNone(reservation2)
             self.assertIsNotNone(reservation2.camera)
             self.assertIsNone(reservation2.failure_reason)
+            self.assertEqual(reservation2.status, ReservedCameraStatus.success)
 
             reservation2.release()

--- a/nion/instrumentation/test/stem_controller_test.py
+++ b/nion/instrumentation/test/stem_controller_test.py
@@ -22,19 +22,19 @@ class TestScanControlClass(unittest.TestCase):
 
     def test_acquire_and_release_ronchigram_camera(self):
         with self._test_context() as test_context:
-            result = test_context.instrument.try_acquire_ronchigram_camera("test")
+            result = test_context.instrument.try_reserve_ronchigram_camera("test")
             self.assertTrue(result.is_valid)
-            self.assertEqual(1, test_context.instrument._ronchigram_camera_acquired_count)
+            self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
 
             test_context.instrument.release_ronchigram_camera()
-            self.assertEqual(0, test_context.instrument._ronchigram_camera_acquired_count)
+            self.assertEqual(0, test_context.instrument._ronchigram_camera_reserved_count)
 
     def test_acquire_ronchigram_camera_twice(self):
         with self._test_context() as test_context:
-            result = test_context.instrument.try_acquire_ronchigram_camera("test")
+            result = test_context.instrument.try_reserve_ronchigram_camera("test")
             self.assertTrue(result.is_valid)
-            self.assertEqual(1, test_context.instrument._ronchigram_camera_acquired_count)
+            self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
 
-            result2 = test_context.instrument.try_acquire_ronchigram_camera("test2")
+            result2 = test_context.instrument.try_reserve_ronchigram_camera("test2")
             self.assertFalse(result2.is_valid)
-            self.assertEqual(1, test_context.instrument._ronchigram_camera_acquired_count)
+            self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)

--- a/nion/instrumentation/test/stem_controller_test.py
+++ b/nion/instrumentation/test/stem_controller_test.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import gc
 import typing
 import unittest
 
+from nion.instrumentation.stem_controller import CameraReservedException
 from nion.instrumentation.test import AcquisitionTestContext
 from nion.swift.test import TestContext
 
-class TestScanControlClass(unittest.TestCase):
 
-    def setUp(self):
+class _ScopeToken:
+    pass
+
+
+class TestSTEMControllerClass(unittest.TestCase):
+    def setUp(self) -> None:
         AcquisitionTestContext.begin_leaks()
         self._test_setup = TestContext.TestSetup()
 
@@ -20,21 +26,70 @@ class TestScanControlClass(unittest.TestCase):
         # subclasses may override this to provide a different configuration
         return AcquisitionTestContext.test_context()
 
-    def test_acquire_and_release_ronchigram_camera(self):
+    def test_reserve_and_release_ronchigram_camera(self):
         with self._test_context() as test_context:
-            result = test_context.instrument.try_reserve_ronchigram_camera("test")
+            scope_token = _ScopeToken()
+            result = test_context.instrument.try_reserve_ronchigram_camera("test", scope_token)
             self.assertTrue(result.is_valid)
             self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
 
             test_context.instrument.release_ronchigram_camera()
             self.assertEqual(0, test_context.instrument._ronchigram_camera_reserved_count)
 
-    def test_acquire_ronchigram_camera_twice(self):
+    def test_reserve_ronchigram_camera_twice(self):
         with self._test_context() as test_context:
-            result = test_context.instrument.try_reserve_ronchigram_camera("test")
+            scope_token = _ScopeToken()
+            result = test_context.instrument.try_reserve_ronchigram_camera("test", scope_token)
             self.assertTrue(result.is_valid)
             self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
 
-            result2 = test_context.instrument.try_reserve_ronchigram_camera("test2")
+            result2 = test_context.instrument.try_reserve_ronchigram_camera("test2", scope_token)
             self.assertFalse(result2.is_valid)
             self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
+
+            test_context.instrument.release_ronchigram_camera()
+
+    def test_collected_scope_token_allows_new_reservation(self):
+        with self._test_context() as test_context:
+            scope_token = _ScopeToken()
+            result = test_context.instrument.try_reserve_ronchigram_camera("test", scope_token)
+            self.assertTrue(result.is_valid)
+            self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
+
+            test_context.instrument.release_ronchigram_camera()
+            self.assertEqual(0, test_context.instrument._ronchigram_camera_reserved_count)
+
+            # Now allow scope_token to be garbage collected and try to reserve again
+            # This tests the scenario where the scope token is collected before the second
+            # reservation attempt, with _ronchigram_camera_reserved_count already at 0
+            scope_token = None
+            gc.collect()
+            scope_token2 = _ScopeToken()
+
+            result2 = test_context.instrument.try_reserve_ronchigram_camera("test2", scope_token2)
+            self.assertTrue(result2.is_valid)
+            self.assertEqual(1, test_context.instrument._ronchigram_camera_reserved_count)
+
+            test_context.instrument.release_ronchigram_camera()
+
+    def test_release_without_reservation(self):
+        with self._test_context() as test_context:
+            # Verify that releasing without a prior reservation is a safe no-op
+            self.assertEqual(0, test_context.instrument._ronchigram_camera_reserved_count)
+            test_context.instrument.release_ronchigram_camera()
+            # Verify state is not corrupted
+            self.assertEqual(0, test_context.instrument._ronchigram_camera_reserved_count)
+
+    def test_reservation_failure_contains_correct_exception(self):
+        with self._test_context() as test_context:
+            scope_token = _ScopeToken()
+            result = test_context.instrument.try_reserve_ronchigram_camera("first_task", scope_token)
+            self.assertTrue(result.is_valid)
+
+            result2 = test_context.instrument.try_reserve_ronchigram_camera("second_task", scope_token)
+            self.assertFalse(result2.is_valid)
+            # Verify the exception is CameraReservedException with the correct task_id
+            self.assertIsInstance(result2.exception, CameraReservedException)
+            self.assertEqual("first_task", result2.exception.task_id)
+
+            test_context.instrument.release_ronchigram_camera()


### PR DESCRIPTION
Fixes #377 

Adds the option to acquire and release the ronchigram camera such that only one task can have the camera at a time using these new functions. This does not affect current usages which will still be able to use the ronchigram_camera property.