### PR TITLE
Avoid numpy array copy on reshape

### DIFF
--- a/nion/instrumentation/camera_base.py
+++ b/nion/instrumentation/camera_base.py
@@ -2955,19 +2955,52 @@ class CameraDataStream(Acquisition.DataStream):
                     data_descriptor=DataAndMetadata.DataDescriptor(False, 0, xdata.datum_dimension_count),
                     timezone=xdata.timezone,
                     timezone_offset=xdata.timezone_offset)
-                # data_count is the total for the data provided by the child data stream. some data streams will
-                # provide a slice into a chunk of data representing the entire stream; whereas others will provide
-                # smaller chunks.
-                data_count = int(numpy.prod(xdata.navigation_dimension_shape, dtype=numpy.int64))
-                data = data_channel_data.reshape((data_count,) + tuple(xdata.datum_dimension_shape))
-                source_slice = (slice(start_index, stop_index),) + (slice(None),) * len(xdata.datum_dimension_shape)
-                data_stream_event = Acquisition.DataStreamEventArgs(channel,
-                                                                    data_metadata,
-                                                                    data,
-                                                                    count,
-                                                                    source_slice,
-                                                                    Acquisition.DataStreamStateEnum.COMPLETE)
-                raw_data_stream_events.append((weakref.ref(self), data_stream_event))
+                if xdata.is_navigable and len(xdata.navigation_dimension_shape) == 2 and not data_channel_data.flags['C_CONTIGUOUS']:
+                    # Non-contiguous navigable data: flyback columns have been removed by slicing, leaving
+                    # a strided array where rows are individually contiguous but cross-row flattening is not.
+                    # Flattening via reshape would force a copy; instead emit one event per row so that
+                    # each passed array is a contiguous view - zero copy throughout.
+                    width = xdata.navigation_dimension_shape[1]
+                    start_row, start_col = divmod(start_index, width)
+                    stop_row, stop_col = divmod(stop_index, width)
+
+                    def _append_row_event(row_data: _NDArray, frame_count: int) -> None:
+                        # row_data is shaped (frame_count, *datum_shape) and is contiguous
+                        row_source_slice = (slice(0, frame_count),) + (slice(None),) * xdata.datum_dimension_count
+                        event = Acquisition.DataStreamEventArgs(
+                            channel, data_metadata, row_data, frame_count, row_source_slice,
+                            Acquisition.DataStreamStateEnum.COMPLETE)
+                        raw_data_stream_events.append((weakref.ref(self), event))
+
+                    if start_row == stop_row:
+                        # all new pixels are within a single row
+                        _append_row_event(data_channel_data[start_row, start_col:stop_col], stop_col - start_col)
+                    else:
+                        # first partial row (if we didn't start at column 0)
+                        if start_col != 0:
+                            _append_row_event(data_channel_data[start_row, start_col:], width - start_col)
+                        # complete rows
+                        first_full_row = start_row + 1 if start_col != 0 else start_row
+                        for row in range(first_full_row, stop_row):
+                            _append_row_event(data_channel_data[row], width)
+                        # last partial row (if we didn't stop exactly at a row boundary)
+                        if stop_col != 0:
+                            _append_row_event(data_channel_data[stop_row, :stop_col], stop_col)
+                else:
+                    # Contiguous data (no flyback gaps, or non-navigable): reshape is a zero-copy view.
+                    # data_count is the total for the data provided by the child data stream. some data streams will
+                    # provide a slice into a chunk of data representing the entire stream; whereas others will provide
+                    # smaller chunks.
+                    data_count = int(numpy.prod(xdata.navigation_dimension_shape, dtype=numpy.int64))
+                    data = data_channel_data.reshape((data_count,) + tuple(xdata.datum_dimension_shape))
+                    source_slice = (slice(start_index, stop_index),) + (slice(None),) * xdata.datum_dimension_count
+                    data_stream_event = Acquisition.DataStreamEventArgs(channel,
+                                                                        data_metadata,
+                                                                        data,
+                                                                        count,
+                                                                        source_slice,
+                                                                        Acquisition.DataStreamStateEnum.COMPLETE)
+                    raw_data_stream_events.append((weakref.ref(self), data_stream_event))
                 # total_count is the total for this entire stream.
                 self.__progress = valid_index / self.__total_count
             self.__last_index = valid_index

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -2566,11 +2566,13 @@ class SynchronizedDataStream(Acquisition.ContainerDataStream):
         self.__stem_controller._enter_synchronized_state(self.__scan_hardware_source, camera=self.__camera_hardware_source)
         self.__scan_hardware_source.acquisition_state_changed_event.fire(True)
         self.__old_record_parameters = self.__scan_hardware_source.get_record_frame_parameters()
+        self.__camera_packet_time = time.perf_counter()
+        self.__scan_packet_time = time.perf_counter()
         super()._prepare_stream(stream_args, index_stack, **kwargs)
 
     def _start_stream(self, stream_args: Acquisition.DataStreamArgs) -> None:
         super()._start_stream(stream_args)
-        # delay setting camera_packet_time and scan_packet time until stream starts in case of long prepare/start time
+        # update setting camera_packet_time and scan_packet_time once stream starts in case of long prepare/start time
         self.__camera_packet_time = time.perf_counter()
         self.__scan_packet_time = time.perf_counter()
 

--- a/nion/instrumentation/scan_base.py
+++ b/nion/instrumentation/scan_base.py
@@ -2566,9 +2566,13 @@ class SynchronizedDataStream(Acquisition.ContainerDataStream):
         self.__stem_controller._enter_synchronized_state(self.__scan_hardware_source, camera=self.__camera_hardware_source)
         self.__scan_hardware_source.acquisition_state_changed_event.fire(True)
         self.__old_record_parameters = self.__scan_hardware_source.get_record_frame_parameters()
+        super()._prepare_stream(stream_args, index_stack, **kwargs)
+
+    def _start_stream(self, stream_args: Acquisition.DataStreamArgs) -> None:
+        super()._start_stream(stream_args)
+        # delay setting camera_packet_time and scan_packet time until stream starts in case of long prepare/start time
         self.__camera_packet_time = time.perf_counter()
         self.__scan_packet_time = time.perf_counter()
-        super()._prepare_stream(stream_args, index_stack, **kwargs)
 
     def _handle_data_received(self, data_stream_event: Acquisition.DataStreamEventArgs) -> None:
         # observe incoming data and mark the last times that a camera or scan packet arrives.

--- a/nion/instrumentation/test/SynchronizedAcquisition_test.py
+++ b/nion/instrumentation/test/SynchronizedAcquisition_test.py
@@ -4,6 +4,7 @@ import numpy
 import threading
 import time
 import unittest
+import unittest.mock
 import uuid
 import tempfile
 import typing
@@ -1389,6 +1390,51 @@ class TestSynchronizedAcquisitionClass(unittest.TestCase):
             self.assertEqual((512,), maker.get_data(Acquisition.Channel("test_eels_camera", "sum")).data_shape)
             self.assertEqual((4, 512), maker.get_data(Acquisition.Channel("test_eels_camera")).data_shape)
             maker = None
+
+    def test_flyback_events_are_zero_copy(self):
+        # Directly exercise _get_raw_data_stream_events with a non-contiguous (flyback-cropped)
+        # data array and verify that every source_data emitted in the events shares memory
+        # with the original array - i.e., no copy was made.
+        raw = numpy.arange(4 * 6 * 8, dtype=numpy.float32).reshape(4, 6, 8)
+        # Simulate flyback crop: slice out first 2 columns to get a non-contiguous view
+        cropped = raw[:, 2:, :]  # shape (4, 4, 8), strided, non-contiguous
+        self.assertFalse(cropped.flags['C_CONTIGUOUS'], "Test setup: cropped array should be non-contiguous")
+
+        # Wrap in navigable xdata (2 collection dims, 1 datum dim)
+        xdata = DataAndMetadata.new_data_and_metadata(
+            cropped,
+            data_descriptor=DataAndMetadata.DataDescriptor(False, 2, 1))
+
+        partial = camera_base.CameraDeviceStreamPartialData(
+            valid_index=4 * 4,  # all 16 pixels valid
+            is_complete=True,
+            xdata=xdata)
+
+        delegate = unittest.mock.MagicMock()
+        delegate.get_next_data.return_value = partial
+        delegate.continue_data.return_value = None
+        delegate.prepare_stream.return_value = 16
+
+        camera_hs = unittest.mock.MagicMock()
+        camera_hs.hardware_source_id = "test_camera"
+        camera_hs.get_expected_dimensions.return_value = (4, 4)
+
+        stream = camera_base.CameraDataStream(camera_hs, unittest.mock.MagicMock(), delegate)
+        stream_args = Acquisition.DataStreamArgs((4, 4))
+        stream._prepare_stream(stream_args, [])
+        stream._start_stream(stream_args)
+
+        events = stream._get_raw_data_stream_events()
+
+        self.assertGreater(len(events), 0, "Expected at least one event to be emitted")
+        for _, event in events:
+            self.assertTrue(
+                numpy.shares_memory(event.source_data, cropped),
+                "source_data does not share memory with the original cropped array"
+            )
+        # The events together must account for all 16 valid pixels
+        total_pixels = sum(event.count for _, event in events if event.count is not None)
+        self.assertEqual(16, total_pixels)
 
     # TODO: check for counts per electron
 


### PR DESCRIPTION
Fixes https://github.com/nion-software/nion-instrumentation/issues/634

This avoids the numpy copy by checking if the data is contiguous (non-contiguous will cause a copy on reshaping the whole array). When it finds non-contiguous data, it will send out the events 1 row at a time only using an already contiguous selection to avoid triggering a copy.

Also moves the initial setting of `scan_packet_time` to the end of start_stream to not include long set-up times in the timeout.

Tested on usim and microscopes, and this allows much larger scans to be successful.