### PR TITLE
Introduce mode streams.

### DIFF
--- a/design/stem_controller.md
+++ b/design/stem_controller.md
@@ -1,0 +1,68 @@
+# STEM Controller Design Notes
+
+## Mode Session Lifecycle and Control-Scoped Observation
+
+This section describes the intent, requirements, and API behavior for mode handling in the STEM controller, with emphasis on client workflows that need to react to mode entry, track a specific control while the mode is active, and clean up when the mode ends.
+
+A mode is represented as a session, not only as a type identifier. The design treats each activation as a distinct lifecycle episode with a unique session identifier. This allows clients to correlate start and end events reliably, even when the same mode type is entered multiple times.
+
+### Functional requirements
+
+The controller must support entering and exiting a mode from the controller side. Entering a mode must return a unique session identifier for that activation. Exiting must target a specific activation by session identifier rather than mode type.
+
+The controller must expose a mode stream that reports lifecycle events as shared truth, regardless of whether the mode was entered by the local controller logic or by device-side behavior. Clients should observe a mode as active when entered and inactive when ended, and should receive an end reason when the mode ends.
+
+The controller must support a common client use case where a specific control is observed only while a matching mode session is active. This must include a way to react to mode completion and stop consuming control updates after mode exit.
+
+Control reliability must be preserved. The API must carry both value and error state so that clients can distinguish valid values from unavailable or unreliable states.
+
+### Data model and semantics
+
+The mode lifecycle is modeled with a `ModeSession` record containing mode identifier, payload, active state, unique session identifier, and optional end reason. The payload carries mode-specific parameters, such as the control name associated with a tracking mode.
+
+End reasons are explicit and represent normal completion, cancellation, device abort, or replacement by another activation. This communicates termination intent and avoids ambiguous boolean-only lifecycle semantics.
+
+For control-scoped mode observation, the API uses `ModeControlSession`, which extends mode session data with the observed control name and a control try-value. The try-value preserves both latest value and any exception indicating reliability issues.
+
+A convenience accessor is provided to read a plain control value. This accessor returns the float only when valid and otherwise raises the underlying exception if one exists. If an invalid state is present without a concrete exception, it raises a value error. This keeps the authoritative state in the try-value while still allowing ergonomic access for callers that want exception semantics.
+
+### API behavior
+
+The mode stream API provides mode lifecycle events for a requested mode stream identifier. The mode control stream API composes mode lifecycle state with control try-value updates for a requested control.
+
+Mode-control composition follows lifecycle gating behavior. Control updates are reflected while the associated mode session is active. After the mode exits, later control updates are ignored for that session state, so the final session snapshot remains stable.
+
+A context-managed mode entry API is provided for client ergonomics and correctness. The context manager enters a mode at scope entry, yields the session identifier, and guarantees exit when the scope ends, including exceptional exits.
+
+### Implementation choices
+
+Mode session and mode control session are implemented as frozen dataclasses.
+
+The mode control stream is implemented as a composed stream adapter. It listens to both mode lifecycle and control try-value updates and emits combined snapshots suitable for UI and tool logic.
+
+Listener cleanup relies on event-listener ownership and dereference behavior already used in the codebase. Explicit finalizer-based cleanup in the composed stream was intentionally avoided.
+
+The instrument-side default mode handling supports arbitrary modes for testing and development. Entering a mode creates a new session record, publishes an active lifecycle update, and tracks the session. Exiting a known session publishes an inactive lifecycle update with completion reason.
+
+### Client integration pattern
+
+A practical client pattern is to observe the mode stream and filter for mode payloads that match expected criteria, such as a target control name. On matching entry, the client creates a mode-control stream for that control and updates display overlays while the session is active. On matching exit, the client detaches listeners and removes overlays.
+
+This pattern enables reactive UI behavior for transient adjustment modes and ensures overlays do not outlive their session.
+
+### Test coverage focus
+
+Tests emphasize stream composition, lifecycle transitions, and context-manager safety.
+
+Coverage verifies that mode-control snapshots are emitted when a mode is active and control values change, that inactive mode state is reported with end reason after exit, and that post-exit control updates do not mutate the completed session snapshot.
+
+Coverage also verifies that context-managed mode handling exits reliably when an exception is raised inside the active scope, which is important for preventing stale active-mode state in real client flows.
+
+Additional high-value tests can focus on overlapping sessions and ensuring session identifiers prevent cross-talk between same-mode activations.
+
+### Future extension: target-scoped modes
+
+If future use cases require scoping modes to specific devices (for example a particular camera), this model can be extended without changing the core lifecycle semantics. A target concept can be added as an explicit parameter to mode entry and stream lookup APIs, while keeping the existing STEM-scoped methods as convenience wrappers.
+
+A practical target model should allow global STEM scope, identifier-based scope, type-based scope, and runtime-object scope. The recommended retrofit path is to add target-aware methods first and retain existing methods as compatibility aliases to the global STEM target.
+

--- a/nion/device_kit/InstrumentDevice.py
+++ b/nion/device_kit/InstrumentDevice.py
@@ -15,6 +15,7 @@ from nion.utils import Stream
 _NDArray = numpy.typing.NDArray[typing.Any]
 
 
+
 class ValueManagerLike(typing.Protocol):
     def get_value(self, name: str) -> typing.Optional[float]:
         ...
@@ -39,6 +40,9 @@ class ValueManagerLike(typing.Protocol):
         ...
 
     def get_control_try_value_stream(self, control_name: str) -> Stream.AbstractStream[stem_controller.TryValue[float]]:
+        ...
+
+    def get_mode_stream(self, mode_stream_id: str) -> Stream.AbstractStream[stem_controller.ModeSession]:
         ...
 
 
@@ -75,6 +79,10 @@ class Instrument(stem_controller.STEMController):
         self.__probe_position: typing.Optional[Geometry.FloatPoint] = None
         self.__live_probe_position: typing.Optional[Geometry.FloatPoint] = None
         self._is_synchronized = False
+
+        # mode tracking for enter_mode/exit_mode
+        self.__active_modes: dict[str, stem_controller.ModeSession] = {}
+        self.__mode_session_counter = 0
 
     def _get_config_property(self, name: str) -> typing.Any:
         if name in ("stage_size_nm", "max_defocus"):
@@ -243,6 +251,90 @@ class Instrument(stem_controller.STEMController):
 
     def get_control_try_value_stream(self, control_name: str) -> Stream.AbstractStream[stem_controller.TryValue[float]]:
         return self.__value_manager.get_control_try_value_stream(control_name)
+
+    def _enter_mode(self, mode_id: str, payload: typing.Mapping[str, typing.Any]) -> str:
+        """
+        Lower-level method to handle mode entry. Subclasses can override this to implement
+        mode-specific behavior. The default implementation allows arbitrary modes for testing.
+
+        Args:
+            mode_id: Identifier for the mode being entered
+            payload: Mode-specific configuration data
+
+        Returns:
+            A unique mode_session_id identifying this mode session
+        """
+        # Default implementation: generate a unique session ID and track the mode
+        self.__mode_session_counter += 1
+        mode_session_id = f"{mode_id}_{self.__mode_session_counter}"
+        mode_session = stem_controller.ModeSession(
+            mode_id=mode_id,
+            payload=dict(payload),
+            active=True,
+            mode_session_id=mode_session_id,
+            end_reason=None
+        )
+        self.__active_modes[mode_session_id] = mode_session
+        # Send the mode entry event to the mode stream
+        mode_stream = typing.cast(Stream.ValueStream[stem_controller.ModeSession], typing.cast(typing.Any, self.__value_manager.get_mode_stream("default")))
+        mode_stream.value = mode_session
+        return mode_session_id
+
+    def _exit_mode(self, mode_session_id: str) -> stem_controller.ModeEndReason | None:
+        """
+        Lower-level method to handle mode exit. Subclasses can override this to implement
+        mode-specific cleanup behavior. The default implementation allows arbitrary modes for testing.
+
+        Args:
+            mode_session_id: The session ID returned by _enter_mode
+
+        Returns:
+            The reason the mode ended, or None if exited normally
+        """
+        # Default implementation: mark the mode as inactive
+        end_reason = stem_controller.ModeEndReason.COMMITTED
+        if mode_session_id in self.__active_modes:
+            old_session = self.__active_modes[mode_session_id]
+            # Create updated session with active=False
+            updated_session = stem_controller.ModeSession(
+                mode_id=old_session.mode_id,
+                payload=old_session.payload,
+                active=False,
+                mode_session_id=old_session.mode_session_id,
+                end_reason=end_reason
+            )
+            self.__active_modes[mode_session_id] = updated_session
+            # Send the mode exit event to the mode stream
+            mode_stream = typing.cast(Stream.ValueStream[stem_controller.ModeSession], typing.cast(typing.Any, self.__value_manager.get_mode_stream("default")))
+            mode_stream.value = updated_session
+        return end_reason
+
+    def enter_mode(self, mode_id: str, payload: typing.Mapping[str, typing.Any]) -> str:
+        """
+        Enter a mode with the given mode_id and payload. This calls _enter_mode which
+        can be overridden by subclasses for mode-specific behavior.
+
+        Args:
+            mode_id: Identifier for the mode being entered
+            payload: Mode-specific configuration data
+
+        Returns:
+            A unique mode_session_id identifying this mode session
+        """
+        return self._enter_mode(mode_id, payload)
+
+    def exit_mode(self, mode_session_id: str) -> None:
+        """
+        Exit the mode associated with the given mode_session_id. This calls _exit_mode
+        which can be overridden by subclasses for mode-specific cleanup.
+
+        Args:
+            mode_session_id: The session ID returned by enter_mode
+        """
+        self._exit_mode(mode_session_id)
+
+    def get_mode_stream(self, mode_stream_id: str) -> Stream.AbstractStream[stem_controller.ModeSession]:
+        return self.__value_manager.get_mode_stream(mode_stream_id)
 
     @property
     def axis_descriptions(self) -> typing.Sequence[stem_controller.AxisDescription]:

--- a/nion/instrumentation/stem_controller.py
+++ b/nion/instrumentation/stem_controller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 # standard libraries
 import abc
 import asyncio
+import contextlib
 import copy
 import dataclasses
 import enum
@@ -321,6 +322,95 @@ class TryValue(typing.Generic[_TryValueType]):
     @property
     def is_valid(self) -> bool:
         return self.exception is None
+
+
+class ModeEndReason(enum.Enum):
+    COMMITTED = "committed"             # completed normally
+    CANCELLED = "cancelled"             # ended without committing
+    DEVICE_ABORTED = "device_aborted"   # device ended it (fault, physical override)
+    SUPERSEDED = "superseded"           # replaced by another activation
+
+
+@dataclasses.dataclass(frozen=True)
+class ModeSession:
+    """One activation episode of a device mode, as seen on the mode stream.
+
+    Reported identically whether this side entered it (via enter_mode) or the
+    device entered it on its own — the stream is the single shared truth about
+    what is currently entered.
+    """
+    mode_id: str                        # kind of mode: "track-control", "demagnetization"
+    payload: typing.Mapping[str, typing.Any]  # parameters: {"control": "C10"}
+    active: bool                        # True on entry, False on exit
+    mode_session_id: str                # unique identity for this one activation
+    end_reason: ModeEndReason | None    # set only when active is False
+
+
+@dataclasses.dataclass(frozen=True)
+class ModeControlSession(ModeSession):
+    """One activation episode of a mode that also tracks a specific control.
+
+    ``control_try_value`` is the authoritative control payload and preserves
+    any current reliability/error state. ``control_value`` is a convenience
+    accessor that returns the float when valid and otherwise raises the
+    underlying exception (falling back to ``ValueError`` if no exception is
+    available).
+    """
+    control_name: str
+    control_try_value: TryValue[float]
+
+    @property
+    def control_value(self) -> float:
+        """Return the control value as a float.
+
+        Raises the underlying exception when ``control_try_value`` is invalid,
+        or ``ValueError`` if the value is unavailable without a specific
+        exception.
+        """
+        control_value = self.control_try_value.value
+        if self.control_try_value.is_valid and control_value is not None:
+            return control_value
+        if self.control_try_value.exception:
+            raise self.control_try_value.exception
+        raise ValueError(f"Control '{self.control_name}' value is not available.")
+
+
+
+class _ModeControlStream(Stream.ValueStream[ModeControlSession]):
+    def __init__(self, mode_stream: Stream.AbstractStream[ModeSession], control_stream: Stream.AbstractStream[TryValue[float]], control_name: str) -> None:
+        self.__mode_stream = mode_stream
+        self.__control_stream = control_stream
+        self.__control_name = control_name
+        self.__mode_session = mode_stream.value
+        self.__control_value = control_stream.value
+        super().__init__(self.__build_value())
+
+        self.__mode_stream_listener = self.__mode_stream.value_stream.listen(ReferenceCounting.weak_partial(_ModeControlStream.__mode_value_changed, self))
+        self.__control_stream_listener = self.__control_stream.value_stream.listen(ReferenceCounting.weak_partial(_ModeControlStream.__control_value_changed, self))
+
+    def __build_value(self) -> typing.Optional[ModeControlSession]:
+        mode = self.__mode_session
+        if mode is None:
+            return None
+        control_value = self.__control_value
+        if control_value is None:
+            return None
+        return ModeControlSession(mode_id=typing.cast(str, mode.mode_id),
+                                  payload=copy.deepcopy(mode.payload),
+                                  active=typing.cast(bool, mode.active),
+                                  mode_session_id=typing.cast(str, mode.mode_session_id),
+                                  end_reason=typing.cast(typing.Optional[ModeEndReason], mode.end_reason),
+                                  control_name=self.__control_name,
+                                  control_try_value=typing.cast(TryValue[float], control_value))
+
+    def __mode_value_changed(self, mode: typing.Optional[ModeSession]) -> None:
+        self.__mode_session = mode
+        self.value = self.__build_value()
+
+    def __control_value_changed(self, control_value: typing.Optional[TryValue[float]]) -> None:
+        self.__control_value = control_value
+        if self.__mode_session and self.__mode_session.active:
+            self.value = self.__build_value()
 
 
 class STEMController(Observable.Observable):
@@ -658,6 +748,74 @@ class STEMController(Observable.Observable):
         If an error is returned, the latest value is set to None.
         """
         raise NotImplementedError()
+
+    def get_mode_stream(self, mode_stream_id: str) -> Stream.AbstractStream[ModeSession]:
+        """Return the read-only mode stream for the given device/sub-system.
+
+        The stream reports mode activations regardless of origin: modes this
+        side enters via enter_mode and modes the device enters on its own both
+        appear here identically. Each activation fires with active=True on entry
+        and active=False (with an end_reason) on exit.
+        """
+        raise NotImplementedError()
+
+    def get_mode_control_stream(self, mode_stream_id: str, control_name: str) -> Stream.AbstractStream[ModeControlSession]:
+        """Return a read-only stream for a control observed while a mode is active.
+
+        The stream reports the same mode session lifecycle as get_mode_stream,
+        while also including the associated control name and its current
+        ``control_try_value``.
+
+        Clients that need reliability/error information should inspect
+        ``control_try_value`` directly. Clients that want a convenient float may
+        use ``control_value``, which raises when the current try-value is not
+        valid.
+        """
+        return typing.cast(Stream.AbstractStream[ModeControlSession], typing.cast(typing.Any, _ModeControlStream(self.get_mode_stream(mode_stream_id), self.get_control_try_value_stream(control_name), control_name)))
+
+    def enter_mode(self, mode_id: str, payload: typing.Mapping[str, typing.Any]) -> str:
+        """Enter a mode from this side and return its mode_session_id.
+
+        Entering drives the corresponding mode stream (an active=True ModeSession is
+        reported to all observers, including us). The returned mode_session_id
+        identifies this specific activation — pass it to exit_mode to end it, and
+        match it against the stream to correlate start and end events.
+        """
+        raise NotImplementedError()
+
+    def exit_mode(self, mode_session_id: str) -> None:
+        """Exit the mode identified by mode_session_id.
+
+        Ends one specific activation (not a kind of mode), driving the mode
+        stream to report active=False. Safe to target only a session that is
+        still active — if the device already ended it (fault, physical override),
+        the stream will have already reported the end and this need not be called.
+        """
+        raise NotImplementedError()
+
+    @contextlib.contextmanager
+    def active_mode(self, mode_id: str, payload: typing.Mapping[str, typing.Any]) -> typing.Iterator[str]:
+        """Context manager for entering and exiting a mode.
+
+        Usage::
+
+            with controller.active_mode("track-control", {"control": "C10"}) as mode_session_id:
+                # perform operations while in mode
+                controller.SetVal("C10", 1.5)
+
+        Args:
+            mode_id: Identifier for the mode being entered
+            payload: Mode-specific configuration data
+
+        Yields:
+            The mode_session_id for the mode session
+
+        """
+        mode_session_id = self.enter_mode(mode_id, payload)
+        try:
+            yield mode_session_id
+        finally:
+            self.exit_mode(mode_session_id)
 
     def get_property(self, name: str) -> typing.Any:
         if name in ("probe_position", "probe_state"):

--- a/nion/instrumentation/test/AcquisitionTestContextConfiguration.py
+++ b/nion/instrumentation/test/AcquisitionTestContextConfiguration.py
@@ -150,6 +150,7 @@ class ValueManager(InstrumentDevice.ValueManagerLike):
             "EELS_MagneticShift_Offset": -20.0
         }
         self.__streams = dict[str, Stream.ValueStream[stem_controller.TryValue[float]]]()
+        self.__mode_stream = Stream.ValueStream[stem_controller.ModeSession](None)
 
     def get_value(self, name: str) -> typing.Optional[float]:
         return self.__values.get(name)
@@ -187,6 +188,9 @@ class ValueManager(InstrumentDevice.ValueManagerLike):
             try_value = self.get_value(control_name)
             self.__streams[control_name] = Stream.ValueStream(stem_controller.TryValue(try_value, Exception() if try_value is None else None))
         return self.__streams[control_name]
+
+    def get_mode_stream(self, mode_stream_id: str) -> Stream.AbstractStream[stem_controller.ModeSession]:
+        return typing.cast(Stream.AbstractStream[stem_controller.ModeSession], typing.cast(typing.Any, self.__mode_stream))
 
 
 class AxisManager(InstrumentDevice.AxisManagerLike):

--- a/nion/instrumentation/test/STEMController_test.py
+++ b/nion/instrumentation/test/STEMController_test.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import unittest
+import typing
+
+from nion.instrumentation import stem_controller
+from nion.instrumentation.test import AcquisitionTestContext
+from nion.swift.test import TestContext
+from nion.utils import Stream
+
+
+class TestModeControlStream(unittest.TestCase):
+    def setUp(self):
+        AcquisitionTestContext.begin_leaks()
+        self._test_setup = TestContext.TestSetup()
+
+    def tearDown(self):
+        self._test_setup = typing.cast(typing.Any, None)
+        AcquisitionTestContext.end_leaks(self)
+
+    def _test_context(self) -> AcquisitionTestContext.AcquisitionTestContext:
+        # subclasses may override this to provide a different configuration
+        return AcquisitionTestContext.test_context()
+
+    def test_mode_control_stream_combines_mode_and_control(self) -> None:
+        with self._test_context() as test_context:
+            controller = test_context.instrument
+
+            stream = controller.get_mode_control_stream("track-control", "C10")
+            events: list[stem_controller.ModeControlSession] = []
+            listener = stream.value_stream.listen(lambda value: events.append(value))
+            self.assertIsNone(stream.value)
+            self.assertEqual(len(events), 0)
+
+            with controller.active_mode("track-control", {"control": "C10"}):
+                controller.SetVal("C10", 1.5)
+
+                self.assertIsNotNone(stream.value)
+                self.assertEqual(stream.value.mode_id, "track-control")
+                self.assertEqual(stream.value.control_name, "C10")
+                self.assertEqual(stream.value.control_try_value.value, 1.5)
+                self.assertTrue(stream.value.control_try_value.is_valid)
+                self.assertEqual(stream.value.control_value, 1.5)
+                self.assertTrue(stream.value.active)
+
+                controller.SetVal("C10", 2.25)
+                self.assertEqual(stream.value.control_try_value.value, 2.25)
+                self.assertEqual(events[-1].control_try_value.value, 2.25)
+                self.assertEqual(stream.value.control_value, 2.25)
+
+            self.assertFalse(stream.value.active)
+            self.assertEqual(stream.value.end_reason, stem_controller.ModeEndReason.COMMITTED)
+            self.assertEqual(stream.value.control_try_value.value, 2.25)
+            self.assertEqual(stream.value.control_value, 2.25)
+            self.assertEqual(events[-1].end_reason, stem_controller.ModeEndReason.COMMITTED)
+
+            control_stream = typing.cast(Stream.ValueStream[stem_controller.TryValue[float]], typing.cast(typing.Any, controller.get_control_try_value_stream("C10")))
+            control_stream.send_value(stem_controller.TryValue(None, Exception("control unavailable")))
+            self.assertEqual(stream.value.control_try_value.value, 2.25)
+            self.assertEqual(events[-1].control_try_value.value, 2.25)
+            listener.close()
+
+    def test_active_mode_exits_when_body_raises(self) -> None:
+        with self._test_context() as test_context:
+            controller = test_context.instrument
+
+            stream = controller.get_mode_control_stream("track-control", "C10")
+            events: list[stem_controller.ModeControlSession] = []
+            listener = stream.value_stream.listen(lambda value: events.append(value))
+
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                with controller.active_mode("track-control", {"control": "C10"}):
+                    controller.SetVal("C10", 3.0)
+                    self.assertIsNotNone(stream.value)
+                    self.assertTrue(stream.value.active)
+                    raise RuntimeError("boom")
+
+            self.assertIsNotNone(stream.value)
+            self.assertFalse(stream.value.active)
+            self.assertEqual(stream.value.end_reason, stem_controller.ModeEndReason.COMMITTED)
+            self.assertTrue(any(event.active for event in events))
+            self.assertFalse(events[-1].active)
+            listener.close()
+
+    def test_mode_entry_can_drive_overlay_lifecycle_for_matching_control(self) -> None:
+        class _ModeOverlayController:
+            def __init__(self, controller: stem_controller.STEMController, mode_stream_id: str, control_filter: str) -> None:
+                self.__controller = controller
+                self.__mode_stream_id = mode_stream_id
+                self.__control_filter = control_filter
+                self.__active_mode_session_id: str | None = None
+                self.__mode_control_stream: Stream.AbstractStream[stem_controller.ModeControlSession] | None = None
+                self.__mode_control_listener: typing.Any = None
+                self.overlay_value: float | None = None
+                self.overlay_active = False
+                self.actions: list[str] = []
+                mode_stream = controller.get_mode_stream(mode_stream_id)
+                self.__mode_listener = mode_stream.value_stream.listen(self.__mode_changed)
+
+            def close(self) -> None:
+                if self.__mode_control_listener:
+                    self.__mode_control_listener.close()
+                    self.__mode_control_listener = None
+                self.__mode_control_stream = None
+                self.__mode_listener.close()
+
+            def __mode_changed(self, mode_session: stem_controller.ModeSession | None) -> None:
+                if mode_session is None:
+                    return
+                if mode_session.active:
+                    control_name = typing.cast(str | None, mode_session.payload.get("control"))
+                    if mode_session.mode_id == self.__mode_stream_id and control_name == self.__control_filter:
+                        self.__active_mode_session_id = mode_session.mode_session_id
+                        self.__mode_control_stream = self.__controller.get_mode_control_stream(self.__mode_stream_id, control_name)
+                        self.__mode_control_listener = self.__mode_control_stream.value_stream.listen(self.__mode_control_changed)
+                        self.overlay_active = True
+                        self.actions.append("create")
+                    return
+                if mode_session.mode_session_id == self.__active_mode_session_id:
+                    if self.__mode_control_listener:
+                        self.__mode_control_listener.close()
+                        self.__mode_control_listener = None
+                    self.__mode_control_stream = None
+                    self.__active_mode_session_id = None
+                    self.overlay_value = None
+                    self.overlay_active = False
+                    self.actions.append("remove")
+
+            def __mode_control_changed(self, mode_control_session: stem_controller.ModeControlSession | None) -> None:
+                if mode_control_session is None:
+                    return
+                if not mode_control_session.active:
+                    return
+                if mode_control_session.mode_session_id != self.__active_mode_session_id:
+                    return
+                control_value = mode_control_session.control_try_value.value
+                if mode_control_session.control_try_value.is_valid and control_value is not None:
+                    self.overlay_value = control_value
+                    self.actions.append(f"update:{control_value}")
+
+        with self._test_context() as test_context:
+            controller = test_context.instrument
+            overlay_controller = _ModeOverlayController(controller, "track-control", "C10")
+            try:
+                with controller.active_mode("track-control", {"control": "C12"}):
+                    controller.SetVal("C12", 1.0)
+                    self.assertFalse(overlay_controller.overlay_active)
+                    self.assertEqual(overlay_controller.actions, [])
+
+                with controller.active_mode("track-control", {"control": "C10"}):
+                    controller.SetVal("C10", 4.5)
+                    self.assertTrue(overlay_controller.overlay_active)
+                    self.assertEqual(overlay_controller.overlay_value, 4.5)
+                    controller.SetVal("C10", 7.25)
+                    self.assertEqual(overlay_controller.overlay_value, 7.25)
+
+                self.assertFalse(overlay_controller.overlay_active)
+                self.assertIsNone(overlay_controller.overlay_value)
+                self.assertEqual(overlay_controller.actions, ["create", "update:4.5", "update:7.25", "remove"])
+            finally:
+                overlay_controller.close()
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+


### PR DESCRIPTION
PLEASE SEE DISCUSSION:

- https://github.com/nion-software/nionswift-instrumentation-kit/issues/389

## Overview

This PR adds mode-session handling to the STEM controller API, including explicit mode lifecycle tracking and control-scoped observation while a mode is active. It is designed to support common UI workflows that react to mode entry, update overlays during active control changes, and cleanly remove overlays on mode exit.

## Changes

- Add mode lifecycle support via `enter_mode`, `exit_mode`, and `get_mode_stream`.
- Add `active_mode(...)` context manager to guarantee balanced mode entry/exit, including exceptional paths.
- Add `get_mode_control_stream(...)` to compose mode-session state with control `TryValue` updates for a specific control.
- Provide concrete mode session records (`ModeSession`, `ModeControlSession`) with explicit end-reason semantics and convenience `control_value` behavior.
- Update instrument default behavior to publish mode entry/exit events to the mode stream.
- Add focused tests for lifecycle transitions, exception-safe mode cleanup, composed stream behavior, and a realistic overlay lifecycle pattern.
- Add design documentation in `design/stem_controller.md` covering requirements, API semantics, and implementation decisions.